### PR TITLE
Bugfix: Calendar.todos() now returns todos without a status

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -613,8 +613,8 @@ class Calendar(DAVObject):
         if not include_completed:
             vnotcompleted = cdav.TextMatch('COMPLETED', negate=True)
             vnotcancelled = cdav.TextMatch('CANCELLED', negate=True)
-            vstatusNotCompleted = cdav.PropFilter('STATUS') + vnotcompleted
-            vstatusNotCancelled = cdav.PropFilter('STATUS') + vnotcancelled
+            vstatusNotCompleted = cdav.PropFilter('STATUS') + vnotcompleted + cdav.NotDefined()
+            vstatusNotCancelled = cdav.PropFilter('STATUS') + vnotcancelled + cdav.NotDefined()
             vnocompletedate = cdav.PropFilter('COMPLETED') + cdav.NotDefined()
             vtodo = (cdav.CompFilter("VTODO") + vnocompletedate +
                      vstatusNotCompleted + vstatusNotCancelled)


### PR DESCRIPTION
This PR fixes #14. The fix was quite simple but seems to do the trick.