### PR TITLE
Replaced vobject by icalendar.

### DIFF
--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -3,10 +3,6 @@
 from .davclient import DAVClient
 from .objects import *
 
-# possibly a bug in the tBaxter fork of vobject, this one has to be
-# imported explicitly to make sure the attribute behaviour gets
-# correctly loaded:
-from vobject import icalendar
 import logging
 
 # Silence notification of no default logging handler

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 from caldav.lib import error
 from caldav.lib.url import URL
-from caldav.objects import Principal
+from caldav.objects import Calendar, Principal
 
 if six.PY3:
     from urllib.parse import unquote
@@ -116,6 +116,16 @@ class DAVClient:
         calendars.
         """
         return Principal(self)
+
+    def calendar(self, url):
+        """
+        Instantiante a calendar by knowing its url.
+
+        This method returns a :class:`caldav.Calendar` object, with
+        higher-level methods for dealing with the calendar
+        events.
+        """
+        return Calendar(self, url)
 
     def propfind(self, url=None, props="", depth=0):
         """

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ if __name__ == '__main__':
         packages=find_packages(exclude=['tests']),
         include_package_data=True,
         zip_safe=False,
-        install_requires=['vobject', 'lxml', 'nose', 'coverage', 'requests', 'six'],
+        install_requires=[
+            'icalendar', 'lxml', 'nose', 'coverage', 'requests', 'six'],
     )

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+import icalendar
 import logging
 import threading
 import time
-import vobject
 import uuid
 from datetime import datetime
 from six import PY3
@@ -361,8 +361,8 @@ class RepeatedFunctionalTestsBaseClass(object):
     def testCreateCalendarAndEventFromVobject(self):
         c = self.principal.make_calendar(name="Yep", cal_id=self.testcal_id)
 
-        # add event from vobject data
-        ve1 = vobject.readOne(ev1)
+        # add event from icalendar data
+        ve1 = icalendar.Calendar.from_ical(ev1)
         c.add_event(ve1)
 
         # c.events() should give a full list of events


### PR DESCRIPTION
I recently added a calendar plugin to the project I work on (Modoboa, https://github.com/modoboa/modoboa-radicale) and during my tests, I realized vobject was extremely slow to parse recurring rules. Since I'm not the first one to report this behaviour, I've replaced it by icalendar which offers better performance.
