### PR TITLE
Fix #52 for real and add a test.

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,32 @@
+import datetime
+import pytz
+import tzlocal
+
+from caldav.objects import _add_missing_tz
+
+SOMEWHERE_REMOTE = pytz.timezone('Brazil/DeNoronha')
+
+def test_add_missing_tz_date():
+    sample = datetime.date(2019,5,14)
+    res = _add_missing_tz(sample)
+    assert res == sample
+
+
+def test_add_missing_tz_dt_with_some_tzinfo():
+    sample = datetime.datetime(2019, 5, 14, 21, 10, 23, 23, tzinfo=SOMEWHERE_REMOTE)
+    res = _add_missing_tz(sample)
+    assert res == sample
+
+
+def test_add_missing_tz_dt_with_local_tz():
+    sample = datetime.datetime(2019,5,14,21,10,23,23).astimezone()
+    res = _add_missing_tz(sample)
+    assert res == sample
+
+
+def test_add_missing_tz_naive_dt():
+    naive_input = datetime.datetime(2019,5,14,21,10,23,23)
+    res = _add_missing_tz(naive_input)
+    # we use pytz as comparison here - could be swapped with the expresssion used in implementation
+    exp = tzlocal.get_localzone().localize(naive_input)
+    assert res == exp


### PR DESCRIPTION
The code so far differed from its documentation (I think it did not work that well in all circumstances).

It also used a wrong way to apply a pytz timezone to an existing datetime (using `replace`) that ignores the time dependency of timezone definitions in pytz (and the olsen DB in general). 

In the PR I used the `datetime` own functionality to localize the `datetime` (supposed to be available in python 2.7 as well). pytz is only (this time correctly) used in the test.

I'm quite sure the code is right now (for what is documented as its purpose), but given we are talking timezones here, I suggest to believe me only after a thorough review and discussion.
