### PR TITLE
Add long description to the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include COPYING.*
 include ChangeLog
+include README.md
 recursive-include tests *

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 This project is a CalDAV ([RFC4791](http://www.ietf.org/rfc/rfc4791.txt)) client library for Python.
 
+Features:
+
+ * create, modify calendar
+ * create, update and delete event
+ * search events by dates
+ * etc.
+
+Links:
+
  * [Pypi](http://pypi.python.org/pypi/caldav)
  * [Documentation](http://packages.python.org/caldav)
+
+Licences:
 
 Caldav is dual-licensed under the [GNU GENERAL PUBLIC LICENSE Version 3](COPYING.GPL) and the [Apache License 2.0](COPYING.APACHE).

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ if __name__ == '__main__':
         name='caldav',
         version=version,
         description="CalDAV (RFC4791) client library",
+        long_description=open("README.md").read(),
         classifiers=["Development Status :: 4 - Beta",
                      "Intended Audience :: Developers",
                      "License :: OSI Approved :: GNU General "


### PR DESCRIPTION
The goal of this PR is to provide a description at https://pypi.org/project/caldav/ in order to replace the current text:
```
The author of this package has not provided a project description
```

I don't know which command is used to create the package but, according to `python setup.py sdist bdist_wheel`, it should work.