### PR TITLE
run tox and add targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+TOX_DIR = .tox
+BIN_DIR = ${TOX_DIR}/py37/bin/
+
+install:
+	tox --recreate --notest
+
+test:
+	tox
+
+package:
+	$(BIN_DIR)pip install wheel
+	$(BIN_DIR)python setup.py sdist bdist_wheel
+
+
+doc:
+	$(BIN_DIR)pip install sphinx
+	$(BIN_DIR)python setup.py build_sphinx
+
+clean:
+	find . -name __pycache__ -exec rm -r {} +
+	rm -rf caldav.egg-info dist docs/build ${TOX_DIR}
+
+mrproper: clean
+	rm -rf ${TOX_DIR}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ detailed-errors = 1
 with-coverage = 1
 cover-package = caldav
 
+[tox:tox]
+envlist = py27,py37
+
 [build_sphinx]
 source-dir = docs/source
 build-dir = docs/build


### PR DESCRIPTION
This PR is a draft for issue https://github.com/python-caldav/caldav/issues/77

The Makefile allows to:
 - run the tests with `tox`,
 - build the package,
 - build the documentation,
 - clean the directory.

It supposes that `tox` is installed on the system. I can modify it to install `tox` package in a `virtualenv` if you prefer.

I'm unsure about the real command runned to build the package but it works.

I can add a command for `nosetest` too.