### PR TITLE
Fix errors with full url response

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -98,6 +98,10 @@ class DAVObject(object):
             resource_name = properties[path][dav.DisplayName.tag]
 
             if resource_type == type or type is None:
+                url = URL(path)
+                if url.hostname is None:
+                    # Quote when path is not a full URL
+                    path = quote(path)
                 # TODO: investigate the RFCs thoroughly - why does a "get
                 # members of this collection"-request also return the
                 # collection URL itself?
@@ -106,7 +110,7 @@ class DAVObject(object):
                 # to RFC 2518, section 5.2.
                 if (self.url.strip_trailing_slash() !=
                         self.url.join(path).strip_trailing_slash()):
-                    c.append((self.url.join(quote(path)), resource_type,
+                    c.append((self.url.join(path), resource_type,
                               resource_name))
 
         return c
@@ -617,8 +621,12 @@ class Calendar(DAVObject):
                 ## not contain anything.  Let's assume the data is
                 ## void and should not be counted.
                 continue
+            url = URL(r)
+            if url.hostname is None:
+                # Quote when result is not a full URL
+                r = quote(r)
             matches.append(
-                comp_class(self.client, url=self.url.join(quote(r)),
+                comp_class(self.client, url=self.url.join(r),
                            data=data, parent=self))
 
         return matches

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -236,6 +236,8 @@ class DAVObject(object):
             rc = properties[path]
         elif exchange_path in properties:
             rc = properties[exchange_path]
+        elif str(self.url) in properties:
+            rc = properties[str(self.url)]
         else:
             raise Exception(
                 "The CalDAV server you are using has a problem with path handling, or the URL is wrong.")


### PR DESCRIPTION
When full url is included in the response shown like below, some errors are apperred.

```xml
<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
    <d:response>
        <d:href>http://cal.example.com/home/bernard/</d:href>
        <d:propstat>
            <d:prop>
                <c:calendar-home-set>
                    <d:href>http://cal.example.com/home/bernard/calendars/</d:href>
                </c:calendar-home-set>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```
_from an example shown in https://tools.ietf.org/html/rfc4791#section-6.2.1_

I fixed them with:
  - avoid `quote` from a target of `url.join` if it's full url because 'https://\~' will be encoded to 'https%3A//\~' occurred with a change of https://github.com/python-caldav/caldav/commit/8f0c0e5d7e4cdf88b5c2e4260f114b405d8e4085
  - use full url as key to get value from properties when nothing matched with path only key
