### PR TITLE
Fix mocked method - davclient is now using requests

### DIFF
--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1212,7 +1212,7 @@ class TestCalDAV:
     a small unit of code works as expected, without any third party
     dependencies)
     """
-    @mock.patch('requests.request')
+    @mock.patch('requests.Session.request')
     def testRequestNonAscii(self, mocked):
         """
         ref https://github.com/python-caldav/caldav/issues/83


### PR DESCRIPTION
Fix mocked method - davclient is now using requests.Session.request rather than requests.request.
