### PR TITLE
Fixed a problem on certain caldav server (LINE Works).

### DIFF
--- a/caldav/elements/cdav.py
+++ b/caldav/elements/cdav.py
@@ -41,6 +41,11 @@ class FreeBusyQuery(BaseElement):
 class Mkcalendar(BaseElement):
     tag = ns("C", "mkcalendar")
 
+class CalendarMultiGet(BaseElement):
+    tag = ns("C", "calendar-multiget")
+
+
+
 
 # Filters
 class Filter(BaseElement):


### PR DESCRIPTION
This server returns empty data result (URL only) from date search.
So we have to re-query the data for every event after fetching urls. calendar_multiget() has been added for it.
And the exception on _calendar_comp_class_by_data() on empty data result has been fixed