### PR TITLE
Fix digest auth with pre utf8 servers (version for master)

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -545,8 +545,8 @@ class DAVClient:
                 self.auth = requests.auth.HTTPDigestAuth(self.username, self.password)
             else:
                 raise NotImplementedError("Auth method %s not supported yet" % auth_type)
-            del self.username
-            del self.password
+            self.username = None
+            self.password = None
             return self.request(url, method, body, headers)
 
         # this is an error condition that should be raised to the application


### PR DESCRIPTION
Some servers, like really old SabreDAV based servers, seem to choke on password if we pass a bytes sequence instead of a string to the "requests" libraries HTTPDigestAuth object.

This fix against master retries authentication in case of authentication failure with the same password as plain string.

Related: #167 (same fix, but for v0.8-stable)

Fixes #165 
Fixes #164