### PR TITLE
add ctx manager support for davclient (PEP 343)

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -337,6 +337,12 @@ class DAVClient:
 
         self._principal = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.session.close()
+
     def principal(self, *largs, **kwargs):
         """
         Convenience method, it gives a bit more object-oriented feel to


### PR DESCRIPTION
This PR adds support for PEP 343 

It makes sense to be able to use with-statements with the DAVClient object, as some might want to close the DAVClient regardless of whether there were any errors. One would have to use a try-finally statement, but PEP 343 recommends using a with-statement


Currently the user has to invoke `DAVClient.session.close()` to fully close the `requests.Session` object. This PR adds support for the following Syntax:

```python3
with DAVClient(url) as dav:
    ...
```
If any error occurs during the with block, the requests session will still be closed regardless

Another improvement should be a publicly available `DAVClient.close()` function which closes the `requests.Session()` adapter, otherwise one has to use `DAVClient.session.close()`

Kind regards
neonfighter28 