### PR TITLE
auth_type to lower case for SabreDAV type servers

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -565,7 +565,7 @@ class DAVClient:
             ## (see commit 13a4714, which introduced this regression)
 
             auth_type = r.headers['WWW-Authenticate']
-            auth_type = auth_type[0:auth_type.find(" ")]
+            auth_type = auth_type[0:auth_type.find(" ")].lower()
 
             if hasattr(self.password, 'decode'):
                 if auth_type == 'basic':


### PR DESCRIPTION
I am unable to connect to my Baikal server as the `WWW-Authenticate` header returns title case `Digest` while the code checks for lowercase `digest`.

Hoping this plus the fixes in https://github.com/python-caldav/caldav/pull/176 will fix the issue described here: https://github.com/home-assistant/core/issues/65804