### PR TITLE
Tox newer environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tests/.noseids
 #*#
 caldav.egg-info/
 tests/conf_private.py
+.tox
+.eggs
+.venv

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -348,7 +348,7 @@ To start the tests code, install everything from the setup.tests_requires list a
 
 .. code-block:: bash
 
-  $ python setup.py nosetests
+  $ python setup.py test
 
 (tox should also work, but it may be needed to look more into it)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ with-coverage = 1
 cover-package = caldav
 
 [tox:tox]
-envlist = py27,py37,py38
+envlist = py27,py37,py38,py39,py310
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,10 @@ cover-package = caldav
 [tox:tox]
 envlist = py27,py37,py38,py39,py310
 
+[testenv]
+commands =
+    python setup.py test
+
 [build_sphinx]
 source-dir = docs/source
 build-dir = docs/build


### PR DESCRIPTION
This patch fixes the tox unit test command, and adds tests for python 3.9 and python 3.10