### PR TITLE
use pytest instead of nosetests

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -50,7 +50,7 @@ def fix(event):
     """
     ## TODO: add ^ before COMPLETED and CREATED?
     ## 1) Add a random time if completed is given as date
-    fixed = re.sub('COMPLETED:(\d+)\s', 'COMPLETED:\g<1>T120000Z',
+    fixed = re.sub(r'COMPLETED:(\d+)\s', r'COMPLETED:\g<1>T120000Z',
                    to_local(event))
 
     ## 2) CREATED timestamps prior to epoch does not make sense,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,9 @@
-[nosetests]
-detailed-errors = 1
-with-coverage = 1
-cover-package = caldav
-
 [tox:tox]
 envlist = py37,py38,py39,py310
 
 [testenv]
-commands =
-    python setup.py test
+deps = --editable .[test]
+commands = pytest {posargs:--cov}
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,18 @@ if __name__ == '__main__':
     except:
         extra_test_packages = ['mock']
 
+    test_packages = [
+        "pytest",
+        "pytest-coverage",
+        "icalendar",
+        "coverage",
+        "nose",
+        "tzlocal",
+        "pytz",
+        "xandikos<0.2.4",
+        "radicale",
+    ]
+
     setup(
         name='caldav',
         version=version,
@@ -49,5 +61,8 @@ if __name__ == '__main__':
         include_package_data=True,
         zip_safe=False,
         install_requires=['vobject', 'lxml', 'requests', 'six'] + extra_packages,
-        tests_require=['icalendar', 'nose', 'coverage', 'tzlocal', 'pytz', 'xandikos<0.2.4', 'radicale'] + extra_test_packages
+        tests_require=test_packages + extra_test_packages,
+        extras_require={
+            "test": test_packages,
+        },
     )


### PR DESCRIPTION
This patch:
- installs pytest and pytest-cov to run the tests
- configure tox so it runs with pytest
- replace nose style assertions `assert_equal`, `assert_not_equal` and `assert_raises` with their pytest equivalents `assert` and `with pytest.raises`
- fixes a couple of warnings raised by pytest about regex string missing `r` flag

Before nose can be totally removed, it is needed to replace the `SkipTest` exception with the pytest `@pytest.mark.skip` or `@pytest.mark.skipif` decorator equivalent.
https://github.com/python-caldav/caldav/blob/6b791de7ccae48901ada8318158ae824f8f36982/tests/test_caldav.py#L25
Though it is not as simple as I expected so I havn't implement this in this patch.

Fixes partially #196