### PR TITLE
Build documentation with tox

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,3 +30,16 @@ jobs:
           key: pip|${{ hashFiles('setup.py') }}|${{ hashFiles('tox.ini') }}
       - run: pip install tox
       - run: tox -e py
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip|${{ hashFiles('setup.py') }}|${{ hashFiles('tox.ini') }}
+      - run: pip install tox
+      - run: tox -e docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from setup import version
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.doctest']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,14 @@
 [tox:tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,docs
 
 [testenv]
 deps = --editable .[test]
 commands = pytest {posargs:--cov}
+
+[testenv:docs]
+deps = sphinx
+commands =
+    python setup.py build_sphinx
 
 [build_sphinx]
 source-dir = docs/source


### PR DESCRIPTION
This patch adds a tox environment that builds the documentation. It is plugged to GHA so documentation build is tested at every commit.