### PR TITLE
make URL picklable

### DIFF
--- a/caldav/lib/url.py
+++ b/caldav/lib/url.py
@@ -100,6 +100,8 @@ class URL:
     # To deal with all kind of methods/properties in the ParseResult
     # class
     def __getattr__(self, attr):
+        if 'url_parsed' not in vars(self):
+            raise AttributeError
         if self.url_parsed is None:
             self.url_parsed = urlparse(self.url_raw)
         if hasattr(self.url_parsed, attr):

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -8,6 +8,7 @@ to emulate server communication.
 
 """
 from datetime import datetime
+import pickle
 
 import caldav
 import icalendar
@@ -873,6 +874,13 @@ END:VCALENDAR
             URL("https://www.example.com:443/b%61r/").canonical()
             == URL("//www.example.com/bar/").canonical()
         )
+
+        # 10) pickle
+        assert (
+            pickle.loads(pickle.dumps(url1))
+            == url1
+        )
+
 
     def testFilters(self):
         filter = cdav.Filter().append(


### PR DESCRIPTION
The pickle module calls `getattr`[1] when unpickling a URL.  Make it so
that `__getattr__` doesn't assume that `self.url_parsed` exists so that
unpickle will work.

[1] https://docs.python.org/3/library/pickle.html#pickle-inst