### PR TITLE
Added get_name convenience method for Calendar

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1272,7 +1272,7 @@ class Calendar(DAVObject):
         """
         Get calendar display name
         """
-        return calendar.get_property(dav.DisplayName())
+        return self.get_property(dav.DisplayName())
 
 
 class ScheduleMailbox(Calendar):

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1267,13 +1267,12 @@ class Calendar(DAVObject):
         root = cdav.CalendarQuery() + [prop, filter]
 
         return self.search(root, comp_class=Journal)
-    
+
     def get_display_name(self):
         """
         Get calendar display name
         """
         return calendar.get_property(dav.DisplayName())
-
 
 
 class ScheduleMailbox(Calendar):

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1267,6 +1267,14 @@ class Calendar(DAVObject):
         root = cdav.CalendarQuery() + [prop, filter]
 
         return self.search(root, comp_class=Journal)
+    
+    def get_name(self):
+        """
+        Get calendar name.
+
+        Returns None if not set 
+        """
+        return self.name
 
 
 class ScheduleMailbox(Calendar):

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -398,7 +398,7 @@ class CalendarSet(DAVObject):
         """
         if name and not cal_id:
             for calendar in self.calendars():
-                display_name = calendar.get_property(dav.DisplayName())
+                display_name = self.get_display_name()
                 if display_name == name:
                     return calendar
         if name and not cal_id:
@@ -485,7 +485,7 @@ class Principal(DAVObject):
         ## Late import.  Prior to 1.0, icalendar is only an optional dependency.
         from icalendar import vCalAddress, vText
 
-        cn = self.get_property(dav.DisplayName())
+        cn = self.get_display_name()
         ids = self.calendar_user_address_set()
         cutype = self.get_property(cdav.CalendarUserType())
         ret = vCalAddress(ids[0])
@@ -641,7 +641,7 @@ class Calendar(DAVObject):
                 ## TODO: investigate.  Those asserts break.
                 error.assert_(False)
                 try:
-                    current_display_name = self.get_property(dav.DisplayName())
+                    current_display_name = self.get_display_name()
                     error.assert_(current_display_name == name)
                 except:
                     log.warning(
@@ -1268,13 +1268,12 @@ class Calendar(DAVObject):
 
         return self.search(root, comp_class=Journal)
     
-    def get_name(self):
+    def get_display_name(self):
         """
-        Get calendar name.
+        Get calendar display name
+        """
+        return calendar.get_property(dav.DisplayName())
 
-        Returns None if not set 
-        """
-        return self.name
 
 
 class ScheduleMailbox(Calendar):

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -398,7 +398,7 @@ class CalendarSet(DAVObject):
         """
         if name and not cal_id:
             for calendar in self.calendars():
-                display_name = self.get_display_name()
+                display_name = calendar.get_display_name()
                 if display_name == name:
                     return calendar
         if name and not cal_id:


### PR DESCRIPTION
Requested get_name convenience method created for Calendar object.

Returns name object attribute.

Docstring indicates that a None object is returned if a name is not set - maybe this is beyond the scope of this method's knowledge though?