### PR TITLE
Expand recurring events client-side

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -876,27 +876,17 @@ class Calendar(DAVObject):
         ## returned.
         objects = self.search(root, comp_class, split_expanded=False)
         if expand:
-            # TODO refactor: since we are not split-expanding here, a "map" approach should suffice
-            expanded_objects = []
             for o in objects:
-                has_expanded = False
                 if not o.data:
-                    expanded_objects.append(o)
                     continue
                 components = o.vobject_instance.components()
                 for i in components:
                     if i.name == "VEVENT":
                         recurrance_properties = ["exdate", "exrule", "rdate", "rrule"]
                         if any(key in recurrance_properties for key in i.contents):
-                            expanded_event = o.expand_rrule(start, end)
-                            expanded_objects.append(expanded_event)
-                            has_expanded = True
-                if not has_expanded:
-                    expanded_objects.append(o)
-        else:
-            expanded_objects = objects
+                            o.expand_rrule(start, end)
 
-        return expanded_objects
+        return objects
 
     def _request_report_build_resultlist(
         self, xml, comp_class=None, props=None, no_calendardata=False

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1036,11 +1036,8 @@ class Calendar(DAVObject):
                 # TODO get from xml
                 raise NotImplementedError("Getting start from xml is not supported")
 
-            # TODO refactor
             for o in objects:
-                has_expanded = False
                 if not o.data:
-                    expanded_objects.append(o)
                     continue
                 components = o.vobject_instance.components()
                 for i in components:
@@ -1690,6 +1687,7 @@ class CalendarObjectResource(DAVObject):
         """
         import recurring_ical_events
 
+        # TODO remove or downgrade to debug
         logging.info(
             "Expanding event %s @ %s (rule: %s)",
             self.instance.vevent.summary.value,

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -876,6 +876,7 @@ class Calendar(DAVObject):
         ## returned.
         objects = self.search(root, comp_class, split_expanded=False)
         if expand:
+            # TODO refactor: since we are not split-expanding here, a "map" approach should suffice
             expanded_objects = []
             for o in objects:
                 has_expanded = False

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -979,7 +979,7 @@ class Calendar(DAVObject):
         * text attribute search parameters: category, uid, summary, omment,
           description, location, status
         * expand - do server side expanding of recurring events/tasks
-        * start, stop: do a time range search
+        * start, end: do a time range search
         * filters - other kind of filters (in lxml tree format)
         * sort_keys - list of attributes to use when sorting
 

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -881,7 +881,7 @@ class Calendar(DAVObject):
                     continue
                 components = o.vobject_instance.components()
                 for i in components:
-                    if i.name == "VEVENT":
+                    if i.name in ("VEVENT", "VTODO"):
                         recurrance_properties = ["exdate", "exrule", "rdate", "rrule"]
                         if any(key in recurrance_properties for key in i.contents):
                             o.expand_rrule(start, end)
@@ -1690,9 +1690,9 @@ class CalendarObjectResource(DAVObject):
         # TODO remove or downgrade to debug
         logging.info(
             "Expanding event %s @ %s (rule: %s)",
-            self.instance.vevent.summary.value,
-            self.instance.vevent.dtstart.value.isoformat(),
-            self.instance.vevent.rrule.value,
+            self.icalendar_object().get('SUMMARY', ''),
+            self.icalendar_object().get('DTSTART', '').dt.strftime("%F %H:%M:%S"),
+            self.icalendar_object()['RRULE'],
         )
         recurrings = recurring_ical_events.of(self.icalendar_instance).between(
             start, end

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1712,6 +1712,7 @@ class CalendarObjectResource(DAVObject):
         calendar = self.icalendar_instance
         calendar.subcomponents = []
         for occurance in recurrings:
+            occurance.add("RECURRENCE-ID", occurance.get("DTSTART"))
             calendar.add_component(occurance)
         # add other components (except for the VEVENT itself and VTIMEZONE which is not allowed on occurance events)
         for component in stripped_event.icalendar_instance.subcomponents:

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -857,9 +857,6 @@ class Calendar(DAVObject):
          * [CalendarObjectResource(), ...]
 
         """
-        if not end and expand:
-            raise error.ReportError("an open-ended date search cannot be expanded")
-
         # build the query
         root, comp_class = self.build_date_search_query(start, end, compfilter, expand)
 

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -63,8 +63,8 @@ def _expand_event(event, start, end):
     # FIXME maybe there is a better way to check for this?
     all_day = not isinstance(event.vobject_instance.vevent.dtstart.value, datetime)
     if not all_day:
-        start_time = event.vobject_instance.vevent.dtstart.value.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
-        end_time = event.vobject_instance.vevent.dtend.value.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+        start_time = event.vobject_instance.vevent.dtstart.value
+        end_time = event.vobject_instance.vevent.dtend.value
     recurrance_properties = ["exdate", "exrule", "rdate", "rrule"]
     # FIXME too much copying
     stripped_event = event.copy(keep_uid=True)

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1687,13 +1687,6 @@ class CalendarObjectResource(DAVObject):
         """
         import recurring_ical_events
 
-        # TODO remove or downgrade to debug
-        logging.info(
-            "Expanding event %s @ %s (rule: %s)",
-            self.icalendar_object().get('SUMMARY', ''),
-            self.icalendar_object().get('DTSTART', '').dt.strftime("%F %H:%M:%S"),
-            self.icalendar_object()['RRULE'],
-        )
         recurrings = recurring_ical_events.of(self.icalendar_instance).between(
             start, end
         )

--- a/tests/compatibility_issues.py
+++ b/tests/compatibility_issues.py
@@ -13,7 +13,7 @@
 ## * Consider how to get this into the documentation
 incompatibility_description = {
     'no_expand':
-        """Server may throw errors when asked to do a expanded date search""",
+        """Server may throw errors when asked to do a expanded date search (this is ignored by the tests now, as we're doing client-side expansion)""",
 
     'no_recurring':
         """Server is having issues with recurring events and/or todos. """
@@ -21,13 +21,13 @@ incompatibility_description = {
         """and events/todos may not be expanded with recurrances""",
 
     'no_recurring_expandation':
-        """Server will not expand recurring events""",
+        """Server will not expand recurring events (this is ignored by the tests now, as we're doing client-side expansion)""",
 
     'no_recurring_todo':
         """Recurring events are supported, but not recurring todos""",
 
     'no_recurring_todo_expand':
-        """Recurring todos aren't expanded""",
+        """Recurring todos aren't expanded (this is ignored by the tests now, as we're doing client-side expansion)""",
 
     'no_scheduling':
         """RFC6833 is not supported""",

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1457,12 +1457,11 @@ class RepeatedFunctionalTestsBaseClass(object):
         # t5 has dtstart and due set prior to the search window
         # t6 has dtstart and due set prior to the search window, but is yearly recurring.
         # What will a date search yield?
-        noexpand = self.check_compatibility_flag("no_expand")
         todos = c.date_search(
             start=datetime(1997, 4, 14),
             end=datetime(2015, 5, 14),
             compfilter="VTODO",
-            expand=not noexpand,
+            expand=True,
         )
         # The RFCs are pretty clear on this.  rfc5545 states:
 
@@ -1493,12 +1492,7 @@ class RepeatedFunctionalTestsBaseClass(object):
         assert len(todos) == foo
 
         ## verify that "expand" works
-        if (
-            not self.check_compatibility_flag("no_recurring_expandation")
-            and not self.check_compatibility_flag("no_expand")
-            and not self.check_compatibility_flag("no_recurring_todo_expand")
-        ):
-            assert len([x for x in todos if "DTSTART:20020415T1330" in x.data]) == 1
+        assert len([x for x in todos if "DTSTART:20020415T1330" in x.data]) == 1
         ## exercise the default for expand (maybe -> False for open-ended search)
         todos = c.date_search(start=datetime(2025, 4, 14), compfilter="VTODO")
 
@@ -1952,39 +1946,31 @@ class RepeatedFunctionalTestsBaseClass(object):
         # if not self.check_compatibility_flag('no_mkcalendar'):
         # assert len(r) == 0
 
-        if not self.check_compatibility_flag("no_expand"):
-            ## With expand=True, we should find one occurrence
-            r = c.date_search(
-                datetime(2008, 11, 1, 17, 00, 00),
-                datetime(2008, 11, 3, 17, 00, 00),
-                expand=True,
-            )
-            assert len(r) == 1
-            assert r[0].data.count("END:VEVENT") == 1
-            ## due to expandation, the DTSTART should be in 2008
-            if not self.check_compatibility_flag("no_recurring_expandation"):
-                assert r[0].data.count("DTSTART;VALUE=DATE:2008") == 1
+        ## With expand=True, we should find one occurrence
+        r = c.date_search(
+            datetime(2008, 11, 1, 17, 00, 00),
+            datetime(2008, 11, 3, 17, 00, 00),
+            expand=True,
+        )
+        assert len(r) == 1
+        assert r[0].data.count("END:VEVENT") == 1
+        ## due to expandation, the DTSTART should be in 2008
+        assert r[0].data.count("DTSTART;VALUE=DATE:2008") == 1
 
-            ## With expand=True and searching over two recurrences ...
-            r = c.date_search(
-                datetime(2008, 11, 1, 17, 00, 00),
-                datetime(2009, 11, 3, 17, 00, 00),
-                expand=True,
-            )
+        ## With expand=True and searching over two recurrences ...
+        r = c.date_search(
+            datetime(2008, 11, 1, 17, 00, 00),
+            datetime(2009, 11, 3, 17, 00, 00),
+            expand=True,
+        )
 
-            ## According to https://tools.ietf.org/html/rfc4791#section-7.8.3, the
-            ## resultset should be one vcalendar with two events.
-            assert len(r) == 1
+        ## According to https://tools.ietf.org/html/rfc4791#section-7.8.3, the
+        ## resultset should be one vcalendar with two events.
+        assert len(r) == 1
 
-            ## not all servers supports expandation
-            if self.check_compatibility_flag("no_recurring_expandation"):
-                ## without expandation, we'll get the original ics,
-                ## with RRULE set
-                assert "RRULE" in r[0].data
-                assert r[0].data.count("END:VEVENT") == 1
-            else:
-                assert "RRULE" not in r[0].data
-                assert r[0].data.count("END:VEVENT") == 2
+        ## not all servers supports expandation
+        assert "RRULE" not in r[0].data
+        assert r[0].data.count("END:VEVENT") == 2
 
         # The recurring events should not be expanded when using the
         # events() method

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -122,6 +122,21 @@ END:VJOURNAL
 END:VCALENDAR
 """
 
+# example from http://www.rfc-editor.org/rfc/rfc5545.txt
+evr = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:19970901T130000Z-123403@example.com
+DTSTAMP:19970901T130000Z
+DTSTART;VALUE=DATE:19971102
+SUMMARY:Our Blissful Anniversary
+TRANSP:TRANSPARENT
+CLASS:CONFIDENTIAL
+CATEGORIES:ANNIVERSARY,PERSONAL,SPECIAL OCCASION
+RRULE:FREQ=YEARLY
+END:VEVENT
+END:VCALENDAR"""
 
 def MockedDAVResponse(text):
     """
@@ -144,6 +159,26 @@ def MockedDAVClient(xml_returned):
     client.request = mock.MagicMock(return_value=MockedDAVResponse(xml_returned))
     return client
 
+class TestExpandRRule:
+    """
+    Tests the expand_rrule method
+    """
+    def setup(self):
+        cal_url = "http://me:hunter2@calendar.example:80/"
+        client = DAVClient(url=cal_url)
+        self.yearly = Event(client, data=evr)
+        
+    def testZero(self):
+        ## evr has rrule yearly and dtstart DTSTART 1997-11-02
+        ## This should cause 0 recurrences:
+        self.yearly.expand_rrule(start=datetime(1998,4,4), end=datetime(1998,10,10))
+        assert len(self.yearly.icalendar_instance.subcomponents) == 0
+
+    def testOne(self):
+        self.yearly.expand_rrule(start=datetime(1998,10,10), end=datetime(1998,12,12))
+        assert len(self.yearly.icalendar_instance.subcomponents) == 1
+        assert not 'RRULE' in self.yearly.icalendar_object()
+        assert 'RECURRENCE-ID' in self.yearly.icalendar_object()
 
 class TestCalDAV:
     """

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -178,6 +178,7 @@ class TestExpandRRule:
         self.yearly.expand_rrule(start=datetime(1998,10,10), end=datetime(1998,12,12))
         assert len(self.yearly.icalendar_instance.subcomponents) == 1
         assert not 'RRULE' in self.yearly.icalendar_object()
+        assert 'UID' in self.yearly.icalendar_object()
         assert 'RECURRENCE-ID' in self.yearly.icalendar_object()
 
     def testThree(self):
@@ -186,7 +187,13 @@ class TestExpandRRule:
         data1 = self.yearly.icalendar_instance.subcomponents[0].to_ical()
         data2 = self.yearly.icalendar_instance.subcomponents[1].to_ical()
         assert data1.replace(b'199711', b'199811') == data2
-        
+
+    def testSplit(self):
+        self.yearly.expand_rrule(start=datetime(1996,10,10), end=datetime(1999,12,12))
+        events = self.yearly.split_expanded()
+        assert len(events) == 3
+        assert len(events[0].icalendar_instance.subcomponents) == 1
+
         
 class TestCalDAV:
     """

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -138,6 +138,23 @@ RRULE:FREQ=YEARLY
 END:VEVENT
 END:VCALENDAR"""
 
+todo6 = """
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+BEGIN:VTODO
+UID:19920901T130000Z-123408@host.com
+DTSTAMP:19920901T130000Z
+DTSTART:19920415T133000Z
+DUE:19920516T045959Z
+SUMMARY:Yearly Income Tax Preparation
+RRULE:FREQ=YEARLY
+CLASS:CONFIDENTIAL
+CATEGORIES:FAMILY,FINANCE
+PRIORITY:1
+END:VTODO
+END:VCALENDAR"""
+
 def MockedDAVResponse(text):
     """
     For unit testing - a mocked DAVResponse with some specific content
@@ -167,6 +184,7 @@ class TestExpandRRule:
         cal_url = "http://me:hunter2@calendar.example:80/"
         client = DAVClient(url=cal_url)
         self.yearly = Event(client, data=evr)
+        self.todo = Todo(client, data=todo6)
         
     def testZero(self):
         ## evr has rrule yearly and dtstart DTSTART 1997-11-02
@@ -186,6 +204,13 @@ class TestExpandRRule:
         assert len(self.yearly.icalendar_instance.subcomponents) == 3
         data1 = self.yearly.icalendar_instance.subcomponents[0].to_ical()
         data2 = self.yearly.icalendar_instance.subcomponents[1].to_ical()
+        assert data1.replace(b'199711', b'199811') == data2
+
+    def testThreeTodo(self):
+        self.todo.expand_rrule(start=datetime(1996,10,10), end=datetime(1999,12,12))
+        assert len(self.todo.icalendar_instance.subcomponents) == 3
+        data1 = self.todo.icalendar_instance.subcomponents[0].to_ical()
+        data2 = self.todo.icalendar_instance.subcomponents[1].to_ical()
         assert data1.replace(b'199711', b'199811') == data2
 
     def testSplit(self):

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -193,6 +193,7 @@ class TestExpandRRule:
         events = self.yearly.split_expanded()
         assert len(events) == 3
         assert len(events[0].icalendar_instance.subcomponents) == 1
+        assert events[1].icalendar_object()['UID'] == '19970901T130000Z-123403@example.com'
 
         
 class TestCalDAV:

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -180,6 +180,14 @@ class TestExpandRRule:
         assert not 'RRULE' in self.yearly.icalendar_object()
         assert 'RECURRENCE-ID' in self.yearly.icalendar_object()
 
+    def testThree(self):
+        self.yearly.expand_rrule(start=datetime(1996,10,10), end=datetime(1999,12,12))
+        assert len(self.yearly.icalendar_instance.subcomponents) == 3
+        data1 = self.yearly.icalendar_instance.subcomponents[0].to_ical()
+        data2 = self.yearly.icalendar_instance.subcomponents[1].to_ical()
+        assert data1.replace(b'199711', b'199811') == data2
+        
+        
 class TestCalDAV:
     """
     Test class for "pure" unit tests (small internal tests, testing that


### PR DESCRIPTION
Hi there,
I've been trying to implement a fix for #157. I've been testing this with my Home Assistant installation (ref. home-assistant/core#40127) and it seems to be working, but I don't know if I'm doing this right (I've worked on this for like 3 hours).
A few challenges I had:

* I'm using a 3rd party library (recurring_ical_events) to expand events, which uses icalendar
* recurring_ical_events returns icalendar.Event objects which need to be converted to caldav.Event
* To do that I needed to wrap those icalendar.Events into icalendar.Calendar
* I then added the other (non-VEVENT) components from the original caldav.Event into all those expanded icalendar.Calendar
* Finally I created caldav.Event like this: `caldav.Event(data=icalendar_Calendar_object.to_ical()`

**Please be aware that this is PoC-quality code: it's meant as a way to address this issue and start having feedback.** I will rewrite it from scratch when everyone is confident that it could work - I will leave the draft status until that.

Before going deeper into this (e.g. writing tests) I'd like to have some feedback please.

This patch needs the following packages installed:

* icalendar
* recurring_ical_events