### PR TITLE
various fixes, improved reliability

### DIFF
--- a/caldav/lib/error.py
+++ b/caldav/lib/error.py
@@ -12,8 +12,8 @@ except:
     ## The default debugmode should be PRODUCTION in official releases,
     ## and DEVELOPMENT when doing beta testing.
     ## TODO: find some way to automate this.
-    # debugmode = "DEVELOPMENT"
-    debugmode = "PRODUCTION"
+    debugmode = "DEVELOPMENT"
+    # debugmode = "PRODUCTION"
 
 log = logging.getLogger("caldav")
 if debugmode.startswith("DEBUG"):

--- a/caldav/lib/python_utilities.py
+++ b/caldav/lib/python_utilities.py
@@ -28,10 +28,7 @@ def to_local(text):
     return text
 
 
-def to_str(text):
-    if text and not isinstance(text, string_types):
-        text = text.decode("utf-8")
-    return text
+to_str = to_local
 
 
 def to_normal_str(text):
@@ -40,10 +37,13 @@ def to_normal_str(text):
     Make sure we return a normal string, no matter what version of
     python ...
     """
-    if PY3 and text and not isinstance(text, str):
+    if text is None:
+        return text
+    if PY3 and not isinstance(text, str):
         text = text.decode("utf-8")
-    elif not PY3 and text and not isinstance(text, str):
+    elif not PY3 and not isinstance(text, str):
         text = text.encode("utf-8")
+    text = text.replace("\r\n", "\n")
     return text
 
 

--- a/caldav/lib/python_utilities.py
+++ b/caldav/lib/python_utilities.py
@@ -14,8 +14,8 @@ def to_wire(text):
         text = bytes(text, "utf-8")
     elif not PY3:
         text = to_unicode(text).encode("utf-8")
-    text = text.replace(b'\n', b'\r\n')
-    text = text.replace(b'\r\r\n', b'\r\n')
+    text = text.replace(b"\n", b"\r\n")
+    text = text.replace(b"\r\r\n", b"\r\n")
     return text
 
 
@@ -24,7 +24,7 @@ def to_local(text):
         return None
     if not isinstance(text, string_types):
         text = text.decode("utf-8")
-    text = text.replace('\r\n', '\n')
+    text = text.replace("\r\n", "\n")
     return text
 
 

--- a/caldav/lib/python_utilities.py
+++ b/caldav/lib/python_utilities.py
@@ -8,16 +8,23 @@ def isPython3():
 
 
 def to_wire(text):
-    if text is not None and isinstance(text, string_types) and PY3:
+    if text is None:
+        return None
+    if isinstance(text, string_types) and PY3:
         text = bytes(text, "utf-8")
     elif not PY3:
         text = to_unicode(text).encode("utf-8")
+    text = text.replace(b'\n', b'\r\n')
+    text = text.replace(b'\r\r\n', b'\r\n')
     return text
 
 
 def to_local(text):
-    if text is not None and not isinstance(text, string_types):
+    if text is None:
+        return None
+    if not isinstance(text, string_types):
         text = text.decode("utf-8")
+    text = text.replace('\r\n', '\n')
     return text
 
 

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -4,7 +4,7 @@ import datetime
 import re
 import uuid
 
-from caldav.lib.python_utilities import to_local
+from caldav.lib.python_utilities import to_normal_str
 
 ## Fixups to the icalendar data to work around compatbility issues.
 
@@ -49,7 +49,9 @@ def fix(event):
     """
     ## TODO: add ^ before COMPLETED and CREATED?
     ## 1) Add a random time if completed is given as date
-    fixed = re.sub(r"COMPLETED:(\d+)\s", r"COMPLETED:\g<1>T120000Z", to_local(event))
+    fixed = re.sub(
+        r"COMPLETED:(\d+)\s", r"COMPLETED:\g<1>T120000Z", to_normal_str(event)
+    )
 
     ## 2) CREATED timestamps prior to epoch does not make sense,
     ## change from year 0001 to epoch.
@@ -85,7 +87,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
     ## (perhaps I should change my position on that soon)
     import icalendar
 
-    ical_fragment = to_local(ical_fragment)
+    ical_fragment = to_normal_str(ical_fragment)
     if not ical_fragment or not re.search("^BEGIN:V", ical_fragment, re.MULTILINE):
         my_instance = icalendar.Calendar()
         my_instance.add("prodid", "-//python-caldav//caldav//" + language)
@@ -100,7 +102,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         if not ical_fragment.startswith("BEGIN:VCALENDAR"):
             ical_fragment = (
                 "BEGIN:VCALENDAR\n"
-                + to_local(ical_fragment.strip())
+                + to_normal_str(ical_fragment.strip())
                 + "\nEND:VCALENDAR\n"
             )
         my_instance = icalendar.Calendar.from_ical(ical_fragment)
@@ -115,7 +117,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
                     )
             else:
                 component.add(prop, props[prop])
-    ret = to_local(my_instance.to_ical())
+    ret = to_normal_str(my_instance.to_ical())
     if ical_fragment and ical_fragment.strip():
         ret = re.sub(
             "^END:V", ical_fragment.strip() + "\nEND:V", ret, flags=re.MULTILINE

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -115,7 +115,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
                     )
             else:
                 component.add(prop, props[prop])
-    ret = my_instance.to_ical()
+    ret = to_local(my_instance.to_ical())
     if ical_fragment and ical_fragment.strip():
         ret = re.sub(
             "^END:V", ical_fragment.strip() + "\nEND:V", ret, flags=re.MULTILINE

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -5,7 +5,6 @@ import re
 import uuid
 
 from caldav.lib.python_utilities import to_local
-from caldav.lib.python_utilities import to_wire
 
 ## Fixups to the icalendar data to work around compatbility issues.
 
@@ -86,8 +85,8 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
     ## (perhaps I should change my position on that soon)
     import icalendar
 
-    ical_fragment = to_wire(ical_fragment)
-    if not ical_fragment or not re.search(b"^BEGIN:V", ical_fragment, re.MULTILINE):
+    ical_fragment = to_local(ical_fragment)
+    if not ical_fragment or not re.search("^BEGIN:V", ical_fragment, re.MULTILINE):
         my_instance = icalendar.Calendar()
         my_instance.add("prodid", "-//python-caldav//caldav//" + language)
         my_instance.add("version", "2.0")
@@ -98,11 +97,11 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         component.add("uid", uuid.uuid1())
         my_instance.add_component(component)
     else:
-        if not ical_fragment.startswith(b"BEGIN:VCALENDAR"):
+        if not ical_fragment.startswith("BEGIN:VCALENDAR"):
             ical_fragment = (
-                b"BEGIN:VCALENDAR\n"
-                + to_wire(ical_fragment.strip())
-                + b"\nEND:VCALENDAR\n"
+                "BEGIN:VCALENDAR\n"
+                + to_local(ical_fragment.strip())
+                + "\nEND:VCALENDAR\n"
             )
         my_instance = icalendar.Calendar.from_ical(ical_fragment)
         component = my_instance.subcomponents[0]
@@ -119,6 +118,6 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
     ret = my_instance.to_ical()
     if ical_fragment and ical_fragment.strip():
         ret = re.sub(
-            b"^END:V", ical_fragment.strip() + b"\nEND:V", ret, flags=re.MULTILINE
+            "^END:V", ical_fragment.strip() + "\nEND:V", ret, flags=re.MULTILINE
         )
     return ret

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -15,10 +15,9 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
-from caldav.lib.python_utilities import to_local
-
-import vobject
 import icalendar
+import vobject
+from caldav.lib.python_utilities import to_local
 from dateutil.rrule import rrulestr
 from lxml import etree
 
@@ -1360,12 +1359,12 @@ class Calendar(DAVObject):
             ## but at one point it broke due to an extra CR in the data.
             ## Usage of the icalendar library increases readability and
             ## reliability
-            item_uid = item.icalendar_object().get('UID', None)
+            item_uid = item.icalendar_object().get("UID", None)
             if item_uid and item_uid == uid:
                 items_found2.append(item)
         if not items_found2:
             raise error.NotFoundError("%s not found on server" % uid)
-        error.assert_(len(items_found2)==1)
+        error.assert_(len(items_found2) == 1)
         return items_found2[0]
 
     def todo_by_uid(self, uid):
@@ -1648,9 +1647,7 @@ class CalendarObjectResource(DAVObject):
         if set_reverse:
             other.set_relation(other=self, reltype=reltype_reverse, set_reverse=False)
 
-        existing_relation = self.icalendar_object().get(
-            "related-to", None
-        )
+        existing_relation = self.icalendar_object().get("related-to", None)
         existing_relations = (
             existing_relation
             if isinstance(existing_relation, list)
@@ -1660,24 +1657,24 @@ class CalendarObjectResource(DAVObject):
             if rel == uid:
                 return
 
-        self.icalendar_object().add(
-            "related-to", uid, parameters={"rel-type": reltype}
-        )
-
+        self.icalendar_object().add("related-to", uid, parameters={"rel-type": reltype})
 
     def icalendar_object(self, assert_one=True):
         """Returns the icalendar subcomponent - which should be an
         Event, Journal, Todo or FreeBusy from the icalendar class
         """
-        ret = [x for x in self.icalendar_instance.subcomponents
-               if not isinstance(x, icalendar.Timezone)]
+        ret = [
+            x
+            for x in self.icalendar_instance.subcomponents
+            if not isinstance(x, icalendar.Timezone)
+        ]
         error.assert_(len(ret) == 1 or not assert_one)
         for x in ret:
             for cl in (
-                    icalendar.Event,
-                    icalendar.Journal,
-                    icalendar.Todo,
-                    icalendar.FreeBusy,
+                icalendar.Event,
+                icalendar.Journal,
+                icalendar.Todo,
+                icalendar.FreeBusy,
             ):
                 if isinstance(x, cl):
                     return x
@@ -1855,7 +1852,7 @@ class CalendarObjectResource(DAVObject):
 
         for x in self.icalendar_instance.subcomponents:
             if not isinstance(x, icalendar.Timezone):
-                error.assert_(x.get('UID', None) == self.id)
+                error.assert_(x.get("UID", None) == self.id)
 
         if path is None:
             path = self.generate_url()
@@ -1892,7 +1889,7 @@ class CalendarObjectResource(DAVObject):
         ## TODO: should try to wrap my head around issues that arises when id contains weird characters.  maybe it's
         ## better to generate a new uuid here, particularly if id is in some unexpected format.
         if not self.id:
-            self.id = self.icalendar_object(assert_one=False)['UID']
+            self.id = self.icalendar_object(assert_one=False)["UID"]
         return self.parent.url.join(quote(self.id.replace("/", "%2F")) + ".ics")
 
     def change_attendee_status(self, attendee=None, **kwargs):

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -17,7 +17,9 @@ from datetime import timezone
 
 import icalendar
 import vobject
-from caldav.lib.python_utilities import to_local
+from caldav.lib.python_utilities import to_normal_str
+from caldav.lib.python_utilities import to_unicode
+from caldav.lib.python_utilities import to_wire
 from dateutil.rrule import rrulestr
 from lxml import etree
 
@@ -37,7 +39,6 @@ except:
 from caldav.lib import error, vcal
 from caldav.lib.url import URL
 from caldav.elements import dav, cdav, ical
-from caldav.lib.python_utilities import to_unicode, to_wire
 
 import logging
 
@@ -2041,14 +2042,30 @@ class CalendarObjectResource(DAVObject):
 
     def _get_data(self):
         if self._data:
-            return self._data
+            return to_normal_str(self._data)
         elif self._vobject_instance:
-            return self._vobject_instance.serialize()
+            return to_normal_str(self._vobject_instance.serialize())
         elif self._icalendar_instance:
-            return to_local(self._icalendar_instance.to_ical())
+            return to_normal_str(self._icalendar_instance.to_ical())
         return None
 
-    data = property(_get_data, _set_data, doc="vCal representation of the object")
+    def _get_wire_data(self):
+        if self._data:
+            return to_wire(self._data)
+        elif self._vobject_instance:
+            return to_wire(self._vobject_instance.serialize())
+        elif self._icalendar_instance:
+            return to_wire(self._icalendar_instance.to_ical())
+        return None
+
+    data = property(
+        _get_data, _set_data, doc="vCal representation of the object as normal string"
+    )
+    wire_data = property(
+        _get_wire_data,
+        _set_data,
+        doc="vCal representation of the object in wire format (UTF-8, CRLN)",
+    )
 
     def _set_vobject_instance(self, inst):
         self._vobject_instance = inst

--- a/examples/basic_usage_examples.py
+++ b/examples/basic_usage_examples.py
@@ -75,6 +75,8 @@ try:
     events_fetched = my_new_calendar.date_search(
         start=datetime(2021, 5, 16), end=datetime(2024, 1, 1), expand=True
     )
+    ## Note: obj.data will always return a normal string, with normal line breaks
+    ## obj.wire_data will return a byte string with CRLN
     print(events_fetched[0].data)
 except:
     print("Your calendar server does apparently not support expanded search")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 ## ATTENTION! when doing releases, the default debugmode in lib/error.py should be set to PRODUCTION.
 ## (TODO: any nicer ways than doing this manually?  Make a "releases" branch, maybe?)
-version = "0.10.0"
+version = "0.10.1.dev0"
 
 if __name__ == "__main__":
     ## For python 2.7 and 3.5 we depend on pytz and tzlocal.  For 3.6 and up, batteries are included.  Same with mock. (But unfortunately the icalendar library only support pytz timezones, so we'll keep pytz around for a bit longer).

--- a/tests/compatibility_issues.py
+++ b/tests/compatibility_issues.py
@@ -347,7 +347,6 @@ robur = [
     'no_journal',
     'no_freebusy_rfc4791',
     'no_todo_datesearch', ## returns nothing
-    'no_recurring', ## See https://github.com/roburio/caldav/issues/28
     'text_search_not_working',
 ]
 

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1613,7 +1613,7 @@ class RepeatedFunctionalTestsBaseClass(object):
             assert len(all_todos) == 1
         self.skip_on_compatibility_flag("rrule_takes_no_count")
         assert len(c.todos()) == 2
-        assert len(all_todos) == 4
+        assert len(all_todos) == 2
         # assert sum([len(x.icalendar_instance.subcomponents) for x in all_todos]) == 5
         t8.complete(handle_rrule=True, rrule_mode="thisandfuture")
         assert len(c.todos()) == 2

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1313,6 +1313,8 @@ class RepeatedFunctionalTestsBaseClass(object):
         journals = c.journals()
         assert len(journals) == 1
         j1_ = c.journal_by_uid(j1.id)
+        j1_.icalendar_instance
+        journals[0].icalendar_instance
         assert j1_.data == journals[0].data
         j2 = c.save_journal(
             dtstart=date(2011, 11, 11),

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1613,7 +1613,7 @@ class RepeatedFunctionalTestsBaseClass(object):
             assert len(all_todos) == 1
         self.skip_on_compatibility_flag("rrule_takes_no_count")
         assert len(c.todos()) == 2
-        assert len(all_todos) == 2
+        assert len(all_todos) == 4
         # assert sum([len(x.icalendar_instance.subcomponents) for x in all_todos]) == 5
         t8.complete(handle_rrule=True, rrule_mode="thisandfuture")
         assert len(c.todos()) == 2


### PR DESCRIPTION
Most objects returned from the caldav server has one vcalendar with one subcomponent, which may be an Event, Todo, Journal or FreeBusy from the icalendar library. However, some calendar servers may also return a Timezone subcomponent. (and in addition, when there are recurrences involved, an object may have multiple recurrences given as subcomponents).

It seems like I've encountered this before and created an object._icalendar_object which looks through the subcomponents and return the first relevant subcomponent found - but then forgotten about this method, and creating code just asserting that the data we're looking for is available as self.icalendar_instance.subcomponents[0].

With this pull request, I'm removing the first underscore from the said method to indicate that it's a public method, the method has been rewritten to call on assert_ if unexpected things happen, and I'm using this method rather than subcomponents[0]

While working on this I stumbled upon some other potential bugs;

* obj.data was inconsistent, sometimes it's python unicode strings, other times it's byte strings. I have fixed the code so that data should always be stored as a unicode string.
* Not all code accessing self.icalendar_object would consider that the icalendar data may be expanded
* self.url not always set correctly after doing a self.copy()

Another en-passant thing, "import icalendar" has been moved to the top of the file.