### PR TITLE
Drop python2 support

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 import logging
 import re
+from urllib.parse import unquote
 
 import requests
 from caldav.elements import cdav
@@ -20,8 +21,6 @@ from caldav.objects import ScheduleInbox
 from caldav.objects import ScheduleOutbox
 from caldav.requests import HTTPBearerAuth
 from lxml import etree
-
-from urllib.parse import unquote
 
 
 class DAVResponse:

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -4,7 +4,6 @@ import logging
 import re
 
 import requests
-import six
 from caldav.elements import cdav
 from caldav.elements import dav
 from caldav.elements import ical
@@ -22,10 +21,7 @@ from caldav.objects import ScheduleOutbox
 from caldav.requests import HTTPBearerAuth
 from lxml import etree
 
-if six.PY3:
-    from urllib.parse import unquote
-else:
-    from urlparse import unquote
+from urllib.parse import unquote
 
 
 class DAVResponse:

--- a/caldav/elements/base.py
+++ b/caldav/elements/base.py
@@ -3,7 +3,6 @@
 from caldav.lib.namespace import nsmap
 from caldav.lib.python_utilities import to_unicode
 from lxml import etree
-from six import PY3
 
 
 class BaseElement(object):
@@ -30,9 +29,7 @@ class BaseElement(object):
         utf8 = etree.tostring(
             self.xmlelement(), encoding="utf-8", xml_declaration=True, pretty_print=True
         )
-        if PY3:
-            return str(utf8, "utf-8")
-        return utf8
+        return str(utf8, "utf-8")
 
     def xmlelement(self):
         root = etree.Element(self.tag, nsmap=nsmap)

--- a/caldav/lib/python_utilities.py
+++ b/caldav/lib/python_utilities.py
@@ -1,21 +1,8 @@
-from six import PY3
-from six import string_types
-
-assert PY3  ## Still using python2?  Write an issue on the github issue tracker, and I will consider to offer some limited python2-support for the 1.x-series of caldav - otherwise I will start cleaning away code for supporting python2 in the 1.1-release
-
-
-def isPython3():
-    """Deprecated. Use six.PY3"""
-    return PY3
-
-
 def to_wire(text):
     if text is None:
         return None
-    if isinstance(text, string_types) and PY3:
+    if isinstance(text, str):
         text = bytes(text, "utf-8")
-    elif not PY3:
-        text = to_unicode(text).encode("utf-8")
     text = text.replace(b"\n", b"\r\n")
     text = text.replace(b"\r\r\n", b"\r\n")
     return text
@@ -24,7 +11,7 @@ def to_wire(text):
 def to_local(text):
     if text is None:
         return None
-    if not isinstance(text, string_types):
+    if not isinstance(text, str):
         text = text.decode("utf-8")
     text = text.replace("\r\n", "\n")
     return text
@@ -35,28 +22,17 @@ to_str = to_local
 
 def to_normal_str(text):
     """
-    A str object is a unicode on python3 and a byte string on python2.
-    Make sure we return a normal string, no matter what version of
-    python ...
+    Make sure we return a normal string
     """
     if text is None:
         return text
-    if PY3 and not isinstance(text, str):
+    if not isinstance(text, str):
         text = text.decode("utf-8")
-    elif not PY3 and not isinstance(text, str):
-        text = text.encode("utf-8")
     text = text.replace("\r\n", "\n")
     return text
 
 
 def to_unicode(text):
-    if (
-        text
-        and isinstance(text, string_types)
-        and not PY3
-        and not isinstance(text, unicode)
-    ):
-        return unicode(text, "utf-8")
-    if PY3 and text and isinstance(text, bytes):
+    if text and isinstance(text, bytes):
         return text.decode("utf-8")
     return text

--- a/caldav/lib/url.py
+++ b/caldav/lib/url.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+from urllib.parse import ParseResult
+from urllib.parse import quote
+from urllib.parse import SplitResult
+from urllib.parse import unquote
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
 from caldav.lib.python_utilities import to_normal_str
 from caldav.lib.python_utilities import to_unicode
-
-from urllib.parse import (
-    ParseResult,
-    SplitResult,
-    urlparse,
-    unquote,
-    quote,
-    urlunparse,
-)
 
 
 class URL:

--- a/caldav/lib/url.py
+++ b/caldav/lib/url.py
@@ -2,29 +2,15 @@
 # -*- encoding: utf-8 -*-
 from caldav.lib.python_utilities import to_normal_str
 from caldav.lib.python_utilities import to_unicode
-from six import PY3
 
-if PY3:
-    from urllib.parse import (
-        ParseResult,
-        SplitResult,
-        urlparse,
-        unquote,
-        quote,
-        urlunparse,
-    )
-else:
-    from urlparse import ParseResult, SplitResult
-    from urlparse import urlparse, urlunparse
-    from urllib import unquote, quote
-
-
-def uc2utf8(input):
-    # argh!  this feels wrong, but seems to be needed.
-    if not PY3 and type(input) == unicode:
-        return input.encode("utf-8")
-    else:
-        return input
+from urllib.parse import (
+    ParseResult,
+    SplitResult,
+    urlparse,
+    unquote,
+    quote,
+    urlunparse,
+)
 
 
 class URL:
@@ -195,12 +181,12 @@ class URL:
             raise ValueError("%s can't be joined with %s" % (self, path))
 
         if path.path[0] == "/":
-            ret_path = uc2utf8(path.path)
+            ret_path = path.path
         else:
             sep = "/"
             if self.path.endswith("/"):
                 sep = ""
-            ret_path = "%s%s%s" % (self.path, sep, uc2utf8(path.path))
+            ret_path = "%s%s%s" % (self.path, sep, path.path)
         return URL(
             ParseResult(
                 self.scheme or path.scheme,

--- a/changelog-1.1.md
+++ b/changelog-1.1.md
@@ -26,6 +26,7 @@ I consider this to be a very minor breakage of my promise not to do changes to t
 * allow conditional load by @tobixen in https://github.com/python-caldav/caldav/pull/276
 
 ### Other
-Lots of work on the test suite, by @tobixen in https://github.com/python-caldav/caldav/pull/264 and https://github.com/python-caldav/caldav/pull/281
+* Lots of work on the test suite, by @tobixen in https://github.com/python-caldav/caldav/pull/264 and https://github.com/python-caldav/caldav/pull/281
+* Last minute fixes in https://github.com/python-caldav/caldav/pull/282 https://github.com/python-caldav/caldav/pull/283 https://github.com/python-caldav/caldav/pull/284 - code style, changelog, version number, compatibility flags in the test suite.
 
-**Full Changelog**: https://github.com/python-caldav/caldav/compare/v1.0.1...v1.1.0
+**Full Changelog**: https://github.com/python-caldav/caldav/compare/v1.0.1...v1.1.1

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ if __name__ == "__main__":
             "vobject",
             "lxml",
             "requests",
-            "six",
             "icalendar",
             "recurring-ical-events>=2.0.0",
         ]

--- a/tests/compatibility_issues.py
+++ b/tests/compatibility_issues.py
@@ -254,6 +254,7 @@ zimbra = [
     'category_search_yields_nothing',
     'text_search_is_exact_match_only',
     'no_relships',
+    'isnotdefined_not_working',
 
     ## extra features not specified in RFC5545
     "calendar_order",
@@ -312,6 +313,7 @@ davical = [
     'vtodo_datesearch_nodtstart_task_is_skipped_in_closed_date_range', ## no issue raised yet
     'isnotdefined_not_working', ## https://gitlab.com/davical-project/davical/-/issues/281
     'fastmail_buggy_noexpand_date_search', ## https://gitlab.com/davical-project/davical/-/issues/280
+    "isnotdefined_not_working",
 ]
 
 google = [
@@ -352,7 +354,8 @@ fastmail = [
     'fastmail_buggy_noexpand_date_search',
     'combined_search_not_working',
     'text_search_is_exact_match_sometimes',
-    'rrule_takes_no_count'
+    'rrule_takes_no_count',
+    'isnotdefined_not_working',
 ]
 
 synology = [
@@ -370,7 +373,8 @@ robur = [
     'no_freebusy_rfc4791',
     'no_todo_datesearch', ## returns nothing
     'text_search_not_working',
-    'no_relships'
+    'no_relships',
+    'isnotdefined_not_working',
 ]
 
 

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -22,17 +22,18 @@ import signal
 import socket
 import sys
 import threading
+from http.server import BaseHTTPRequestHandler
+from http.server import HTTPServer
+from socketserver import ThreadingMixIn
 from time import sleep
 from types import CodeType
 from types import FrameType
+from urllib import parse
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from caldav.lib.python_utilities import to_local
 from caldav.lib.python_utilities import to_wire
-
-from urllib import parse
-from urllib.parse import urlparse, urlunparse
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from socketserver import ThreadingMixIn
 
 __version__ = "0.3.1"
 

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -28,18 +28,11 @@ from types import FrameType
 
 from caldav.lib.python_utilities import to_local
 from caldav.lib.python_utilities import to_wire
-from six import PY3
 
-if PY3:
-    from urllib import parse
-    from urllib.parse import urlparse, urlunparse
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-    from socketserver import ThreadingMixIn
-else:
-    from urlparse import urlparse as parse
-    from urlparse import urlparse, urlunparse
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-    from SocketServer import ThreadingMixIn
+from urllib import parse
+from urllib.parse import urlparse, urlunparse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
 
 __version__ = "0.3.1"
 

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -41,7 +41,6 @@ from caldav.objects import FreeBusy
 from caldav.objects import Principal
 from caldav.objects import Todo
 from requests.packages import urllib3
-from six import PY3
 
 from . import compatibility_issues
 from .conf import caldav_servers
@@ -70,10 +69,7 @@ if test_radicale:
     import radicale.server
     import socket
 
-if PY3:
-    from urllib.parse import urlparse
-else:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 log = logging.getLogger("caldav")
 

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -35,15 +35,10 @@ from caldav.objects import FreeBusy
 from caldav.objects import Journal
 from caldav.objects import Principal
 from caldav.objects import Todo
-from six import PY3
 
 
-if PY3:
-    from urllib.parse import urlparse
-    from unittest import mock
-else:
-    from urlparse import urlparse
-    import mock
+from urllib.parse import urlparse
+from unittest import mock
 
 ## Some example icalendar data partly copied from test_caldav.py
 ev1 = """BEGIN:VCALENDAR
@@ -263,14 +258,11 @@ class TestCalDAV:
         assert response.status == 200
         assert response.tree is None
 
-        if PY3:
-            response = client.put(
-                "/foo/møøh/bar".encode("utf-8"),
-                "bringebærsyltetøy 北京 пиво".encode("utf-8"),
-                {},
-            )
-        else:
-            response = client.put(u"/foo/møøh/bar", "bringebærsyltetøy 北京 пиво", {})  # fmt: skip
+        response = client.put(
+            "/foo/møøh/bar".encode("utf-8"),
+            "bringebærsyltetøy 北京 пиво".encode("utf-8"),
+            {},
+        )
         assert response.status == 200
         assert response.tree is None
 

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -10,6 +10,8 @@ import pickle
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from unittest import mock
+from urllib.parse import urlparse
 
 import caldav
 import icalendar
@@ -35,10 +37,6 @@ from caldav.objects import FreeBusy
 from caldav.objects import Journal
 from caldav.objects import Principal
 from caldav.objects import Todo
-
-
-from urllib.parse import urlparse
-from unittest import mock
 
 ## Some example icalendar data partly copied from test_caldav.py
 ev1 = """BEGIN:VCALENDAR


### PR DESCRIPTION
Python 2 went EOL on 1/1/2020 and we receive no more support from the Python Core Team after Python 2.7.18 even for known security issues.

This removes the six package from dependencies.