### PR TITLE
Bugfixes, docfix and making __version__ available

### DIFF
--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -3,6 +3,8 @@ import logging
 
 import vobject.icalendar
 
+__version__ = "0.12.0.dev0"
+
 from .davclient import DAVClient
 from .objects import *
 

--- a/caldav/lib/error.py
+++ b/caldav/lib/error.py
@@ -3,17 +3,18 @@
 import logging
 from collections import defaultdict
 
+from caldav import __version__
+
 try:
     import os
 
     ## one of DEBUG_PDB, DEBUG, DEVELOPMENT, PRODUCTION
     debugmode = os.environ["PYTHON_CALDAV_DEBUGMODE"]
 except:
-    ## The default debugmode should be PRODUCTION in official releases,
-    ## and DEVELOPMENT when doing beta testing.
-    ## TODO: find some way to automate this.
-    # debugmode = "DEVELOPMENT"
-    debugmode = "PRODUCTION"
+    if "dev" in __version__:
+        debugmode = "DEVELOPMENT"
+    else:
+        debugmode = "PRODUCTION"
 
 log = logging.getLogger("caldav")
 if debugmode.startswith("DEBUG"):

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -110,7 +110,10 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
             if prop in ("child", "parent"):
                 for value in props[prop]:
                     component.add(
-                        "related-to", props[prop], parameters={"rel-type": prop.upper()}
+                        "related-to",
+                        props[prop],
+                        parameters={"reltype": prop.upper()},
+                        encode=True,
                     )
             else:
                 component.add(prop, props[prop])

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1769,8 +1769,10 @@ class CalendarObjectResource(DAVObject):
                 return
 
         self.icalendar_component.add(
-            "related-to", uid, parameters={"rel-type": reltype}
+            "related-to", uid, parameters={"RELTYPE": reltype}, encode=True
         )
+
+        self.save()
 
     def _get_icalendar_component(self, assert_one=True):
         """Returns the icalendar subcomponent - which should be an
@@ -1972,6 +1974,8 @@ class CalendarObjectResource(DAVObject):
             id = self.id
         if not id:
             id = i.pop("UID", None)
+            if id:
+                id = str(id)
         if not path and getattr(self, "path", None):
             path = self.path
         if id is None and path is not None and str(path).endswith(".ics"):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,8 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.append(os.path.abspath("../../"))
-from setup import version
+sys.path.append(os.path.abspath("../"))
+from caldav import __version__ as version
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,51 @@ https://github.com/python-caldav/caldav - if you have problems using
 the library (including problems understanding the documentation),
 please feel free to report it on the issue tracker there.
 
+Backward compatibility support
+==============================
+
+As of writing, we're still using 0.x-version numbers, which indicates
+that the product is not ready for usage in a production environment.
+The caldav library is production-ready, but there will be some
+API-changes in 1.x.  If you have any suggestions on things that should
+be cleaned up in 1.x, please comment on
+https://github.com/python-caldav/caldav/issues/92
+
+Even if we are in the 0.x-series, we're doing the uttermost to
+preserve backward-compatibility - and the 0.x-interface will continue
+working at least until the release of 2.x, and at least for five years
+after the 1.0-release.
+
+Notices will be logged when using legacy interface.  (See also
+https://github.com/python-caldav/caldav/issues/240)
+
+
+Python compatibility notice
+===========================
+
+Most of the code is regularly tested towards all officially supported
+versions of Python with the latest releases of the libraries required.
+
+There are still a lot of installations of "end-of-life"-versions of
+python in the wild, particularly some OS-distributions that are
+officially supported are using python versions that are not supported
+(meaning, that at least in theory the OS distributors takes
+responsibility of back-porting critical security fixes).  This
+currently includes Python2.
+
+The policy is to be as pragmatic as possible, however as unsupported
+versions of Python aren't regularly tested, there is kind of
+Schrödingers support for old versions - it may or may not work, all
+until it's tested (this particularly applies to Python2 - we do have
+quite some code in the library still for dual support of Python2 and
+Python3).  Please report issues if you have problems running the
+caldav library with old python versions.  If it's easy to find a
+work-around I will do so (like I did reverting new-style `f"{foo}"`
+strings into old-style `"%s" % foo` strings).  If it's non-trivial to
+fix things, we will officially abandon legacy support.
+
+See also https://github.com/python-caldav/caldav/pull/228
+
 Objective and scope
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
             "requests",
             "six",
             "icalendar",
-            "recurring-ical-events>=1.1.0b",
+            "recurring-ical-events>=2.0.0",
         ]
         + extra_packages,
         tests_require=test_packages + extra_test_packages,

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,27 @@
 #!/usr/bin/python
 # -*- encoding: utf-8 -*-
+import ast
+import re
 import sys
 
 from setuptools import find_packages
 from setuptools import setup
 
-## ATTENTION! when doing releases, the default debugmode in lib/error.py should be set to PRODUCTION.
-## (TODO: any nicer ways than doing this manually?  Make a "releases" branch, maybe?)
-version = "0.11.0"
+## I believe it's good practice to keep the version number
+## available as package.__version__
+
+## It is defitively good practice not to have to maintain the
+## version number several places.
+
+# However, there seems to be no "best current practice" on how
+## to set up version number in the setup.py file?
+
+## I've copied the following from the icalendar library:
+_version_re = re.compile(r"__version__\s+=\s+(.*)")
+with open("caldav/__init__.py", "rb") as f:
+    version = str(
+        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
+    )
 
 if __name__ == "__main__":
     ## For python 2.7 and 3.5 we depend on pytz and tzlocal.  For 3.6 and up, batteries are included.  Same with mock. (But unfortunately the icalendar library only support pytz timezones, so we'll keep pytz around for a bit longer).


### PR DESCRIPTION
Some unrelated, minor commits:

* Bugfix, the parent/child code didn't work - now with test code.
* The version number has been moved from setup.py to __init__.py
* Documentation wrg backward-compatibility support and legacy python support
* Now we are incompatible with recurring_ical_event 1.x, mark this in setup.py