### PR TITLE
Meta - documentation, comments, example code

### DIFF
--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import vobject.icalendar
 
-__version__ = "0.12.0.dev0"
+__version__ = "1.0.0.dev0"
 
 from .davclient import DAVClient
 from .objects import *

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -803,6 +803,9 @@ class Calendar(DAVObject):
     def build_date_search_query(
         self, start, end=None, compfilter="VEVENT", expand="maybe"
     ):
+        """
+        WARNING: DEPRECATED
+        """
         ## This is dead code.  It has no tests.  It was made for usage
         ## by the date_search method, but I've decided not to use it
         ## there anymore.  Most likely nobody is using this, as it's
@@ -853,7 +856,7 @@ class Calendar(DAVObject):
         """
         ## TODO: upgrade to warning and error before removing this method
         logging.info(
-            "DEPRECATION NOTICE: The calendar.date_search method may be removed in some far future release of the caldav library.  Use calendar.search instead"
+            "DEPRECATION NOTICE: The calendar.date_search method may be removed in release 2.0 of the caldav library.  Use calendar.search instead"
         )
 
         if verify_expand:
@@ -2274,12 +2277,13 @@ class CalendarObjectResource(DAVObject):
         This method will return DURATION if set, otherwise the
         difference between DUE and DTSTART (if both of them are set).
 
-        Arguably, this logic belongs to the icalendar/vobject layer as
-        it has nothing to do with the caldav protocol.
-
         TODO: should be fixed for Event class as well (only difference
         is that DTEND is used rather than DUE) and possibly also for
         Journal (defaults to one day, probably?)
+
+        WARNING: this method is likely to be deprecated and moved to
+        the icalendar library.  If you decide to use it, please put
+        caldav<2.0 in the requirements.
         """
         i = self.icalendar_component
         return self._get_duration(i)
@@ -2643,6 +2647,10 @@ class Todo(CalendarObjectResource):
         If DTSTART and DUE/DTEND is already set, one of them should be moved.  Which one?  I believe that for EVENTS, the DTSTART should remain constant and DTEND should be moved, but for a task, I think the due date may be a hard deadline, hence by default we'll move DTSTART.
 
         TODO: can this be written in a better/shorter way?
+
+        WARNING: this method is likely to be deprecated and moved to
+        the icalendar library.  If you decide to use it, please put
+        caldav<2.0 in the requirements.
         """
         i = self.icalendar_component
         return self._set_duration(i, duration, movable_attr)
@@ -2668,6 +2676,10 @@ class Todo(CalendarObjectResource):
     def get_due(self):
         """
         A VTODO may have due or duration set.  Return or calculate due.
+
+        WARNING: this method is likely to be deprecated and moved to
+        the icalendar library.  If you decide to use it, please put
+        caldav<2.0 in the requirements.
         """
         i = self.icalendar_component
         if "DUE" in i:
@@ -2681,6 +2693,10 @@ class Todo(CalendarObjectResource):
         """The RFC specifies that a VTODO cannot have both due and
         duration, so when setting due, the duration field must be
         evicted
+
+        WARNING: this method is likely to be deprecated and moved to
+        the icalendar library.  If you decide to use it, please put
+        caldav<2.0 in the requirements.
         """
         i = self.icalendar_component
         duration = self.get_duration()

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -107,9 +107,17 @@ class DAVObject(object):
         return str(self.url.canonical())
 
     def children(self, type=None):
-        """
-        List children, using a propfind (resourcetype) on the parent object,
+        """List children, using a propfind (resourcetype) on the parent object,
         at depth = 1.
+
+        TODO: This is old code, it's querying for DisplayName and
+        ResourceTypes prop and returning a tuple of those.  Those two
+        are relatively arbitrary.  I think it's mostly only calendars
+        having DisplayName, but it may make sense to ask for the
+        children of a calendar also as an alternative way to get all
+        events?  It should be redone into a more generic method, and
+        it should probably return a dict rather than a tuple.  We
+        should also look over to see if there is any code duplication.
         """
         c = []
 

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -763,6 +763,12 @@ class Calendar(DAVObject):
             other.set_relation(other=uid, reltype=reverse_reltype, set_reverse=False)
 
     ## legacy aliases
+    ## TODO: should be deprecated
+
+    ## TODO: think more through this - is `save_foo` better than `add_foo`?
+    ## `save_foo` should not be used for updating existing content on the
+    ## calendar!
+
     add_event = save_event
     add_todo = save_todo
     add_journal = save_journal

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,17 +24,14 @@ please feel free to report it on the issue tracker there.
 Backward compatibility support
 ==============================
 
-As of writing, we're still using 0.x-version numbers, which indicates
-that the product is not ready for usage in a production environment.
-The caldav library is production-ready, but there will be some
-API-changes in 1.x.  If you have any suggestions on things that should
-be cleaned up in 1.x, please comment on
-https://github.com/python-caldav/caldav/issues/92
+The 1.x version series is supposed to be fully backwards-compatible with version
+0.x, and is intended to be maintained at least until 2026.
 
-Even if we are in the 0.x-series, we're doing the uttermost to
-preserve backward-compatibility - and the 0.x-interface will continue
-working at least until the release of 2.x, and at least for five years
-after the 1.0-release.
+API-changes will be slowly introduced in 1.x.  API marked as
+deprecated in 0.x will most likely be removed in version 2.0, API
+marked with deprecating-warnings in 1.x will most likely be removed in
+3.0.  If you have any suggestions on API-changes, please comment on
+https://github.com/python-caldav/caldav/issues/92
 
 Notices will be logged when using legacy interface.  (See also
 https://github.com/python-caldav/caldav/issues/240)
@@ -56,13 +53,20 @@ currently includes Python2.
 The policy is to be as pragmatic as possible, however as unsupported
 versions of Python aren't regularly tested, there is kind of
 Schrödingers support for old versions - it may or may not work, all
-until it's tested (this particularly applies to Python2 - we do have
-quite some code in the library still for dual support of Python2 and
-Python3).  Please report issues if you have problems running the
-caldav library with old python versions.  If it's easy to find a
-work-around I will do so (like I did reverting new-style `f"{foo}"`
-strings into old-style `"%s" % foo` strings).  If it's non-trivial to
-fix things, we will officially abandon legacy support.
+until it's tested.
+
+Python2 has been unlikely to work for some time due to lack of testing
+and due to dependencies on other libraries that doesn't support
+python2.  Pyhton2 is officially not supported starting from version
+1.0 - however, code for supporting python2 will only be cleaned
+properly away in version 1.1 (and may be postponed if anyone
+protests).
+
+Please report issues if you have problems running the caldav library
+with old python versions.  If it's easy to find a work-around I will
+do so (like I did reverting new-style `f"{foo}"` strings into
+old-style `"%s" % foo` strings).  If it's non-trivial to fix things,
+we will officially abandon legacy support.
 
 See also https://github.com/python-caldav/caldav/pull/228
 
@@ -103,14 +107,16 @@ support RFC 5545 (icalendar).  It's outside the scope of this library
 to implement logic for parsing and modifying RFC 5545, instead we
 depend on another library for that.
 
-RFC 5545 describes the icalendar format.  Constructing or parsing icalendar data was considered out of the scope of this library, but we do make exceptions - like, there is a method to complete a task - it involves editing the icalendar data, and now the `save_event`, `save_todo` and `save_journal` methods are able to construct icalendar data if needed.
+RFC 5545 describes the icalendar format.  Constructing or parsing
+icalendar data was considered out of the scope of this library, but we
+do make exceptions - like, there is a method to complete a task - it
+involves editing the icalendar data, and now the `save_event`,
+`save_todo` and `save_journal` methods are able to construct icalendar
+data if needed.
 
 There exists two libraries supporting RFC 5545, vobject and icalendar.
-The icalendar library seems to be more popular.  Version 0.x depends
-on vobject, version 1.x will depend on icalendar.  Version 0.7 and
-higher supports both, but the "alternative" library will only be
-loaded when/if needed, and the vobject support may be deprecated in
-the future.
+The icalendar library seems to be more popular.  Version 1.0 depends
+on both, but we're slowly moving towards using icalendar internally.
 
 Misbehaving server implementations
 ----------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,14 +24,15 @@ please feel free to report it on the issue tracker there.
 Backward compatibility support
 ==============================
 
-The 1.x version series is supposed to be fully backwards-compatible with version
-0.x, and is intended to be maintained at least until 2026.
+The 1.x version series is supposed to be fully backwards-compatible
+with version 0.x, and is intended to be maintained at least
+until 2026.
 
 API-changes will be slowly introduced in 1.x.  API marked as
-deprecated in 0.x will most likely be removed in version 2.0, API
-marked with deprecating-warnings in 1.x will most likely be removed in
-3.0.  If you have any suggestions on API-changes, please comment on
-https://github.com/python-caldav/caldav/issues/92
+deprecated in 0.x or 1.0 will most likely be removed in version 2.0,
+API marked with deprecating-warnings in 1.x or 2.0 will most likely be
+removed in 3.0.  If you have any suggestions on API-changes, please
+comment on https://github.com/python-caldav/caldav/issues/92
 
 Notices will be logged when using legacy interface.  (See also
 https://github.com/python-caldav/caldav/issues/240)
@@ -80,6 +81,12 @@ search, etc) should be trivial to accomplish even if the end-user of
 the library has no or very little knowledge of the caldav, webdav or
 icalendar standards.  The library should be agile enough to allow
 "power users" to do more advanced stuff.
+
+The library aims to take a pragmatic approach towards compatibility -
+it should work as well as possible for as many as possible.  This also
+means the library will modify icalendar data to get around known
+compatibility issues - so no guarantee is given on the immutability of
+icalendar data.
 
 RFC 4791, 2518, 5545, 6638 et al
 --------------------------------

--- a/examples/basic_usage_examples.py
+++ b/examples/basic_usage_examples.py
@@ -18,179 +18,308 @@ caldav_url = "https://calendar.example.com/dav"
 username = "somebody"
 password = "hunter2"
 
-## When using the caldav library, one should always start off with initiating a
-## DAVClient object, which should contain connection details and credentials.
-## Initiating the object does not cause any requests to the server, so this
-## will not break even if caldav url is set to example.com
-client = caldav.DAVClient(url=caldav_url, username=username, password=password)
 
-## For the convenience, if things are correctly set up in test config,
-## the code below may replace the client object with one that works.
-if "example.com" in caldav_url and password == "hunter2":
-    from tests.conf import client as client_
+def run_examples():
+    """
+    Run through all the examples, one by one
+    """
+    ## We need a client object.
+    ## The client object stores http session information, username, password, etc.
+    ## As of 1.0, Initiating the client object will not cause any server communication,
+    ## so the credentials aren't validated.
+    ## The client object can be used as a context manager, like this:
+    with caldav.DAVClient(
+        url=caldav_url, username=username, password=password
+    ) as client:
 
-    client = client_()
+        ## Typically the next step is to fetch a principal object.
+        ## This will cause communication with the server.
+        my_principal = client.principal()
 
-## Typically the next step is to fetch a principal object.
-## This will cause communication with the server.
-my_principal = client.principal()
+        ## The principals calendars can be fetched like this:
+        calendars = my_principal.calendars()
 
-## The principals calendars can be fetched like this:
-calendars = my_principal.calendars()
-if calendars:
-    ## Some calendar servers will include all calendars you have
-    ## access to in this list, and not only the calendars owned by
-    ## this principal.
-    print("your principal has %i calendars:" % len(calendars))
-    for c in calendars:
-        print("    Name: %-20s  URL: %s" % (c.name, c.url))
-else:
-    print("your principal has no calendars")
+        ## print out some information
+        print_calendars_demo(calendars)
 
-## Let's try to find or create a calendar ...
-try:
-    ## This will raise a NotFoundError if calendar does not exist
-    my_new_calendar = my_principal.calendar(name="Test calendar")
-    assert my_new_calendar
-    ## calendar did exist, probably it was made on an earlier run
-    ## of this script
-except caldav.error.NotFoundError:
-    ## Let's create a calendar
-    my_new_calendar = my_principal.make_calendar(name="Test calendar")
+        ## This cleans up from previous runs, if needed:
+        find_delete_calendar_demo(my_principal, "Test calendar from caldav examples")
 
-## Let's add an event to our newly created calendar
-## (This usage pattern is new from v0.9.
-## Earlier save_event would only accept some ical data)
-my_event = my_new_calendar.save_event(
-    dtstart=datetime(2020, 5, 17, 8),
-    dtend=datetime(2020, 5, 18, 1),
-    summary="Do the needful",
-    rrule={"FREQ": "YEARLY"},
-)
+        ## Let's create a new calendar to play with.
+        ## This may raise an error for multiple reasons:
+        ## * server may not support it (it's not mandatory in the CalDAV RFC)
+        ## * principal may not have the permission to create calendars
+        ## * some cloud providers have a global namespace
+        my_new_calendar = my_principal.make_calendar(
+            name="Test calendar from caldav examples"
+        )
 
-## Let's search for the newly added event.
-## (this may fail if the server doesn't support expand)
-print("Here is some icalendar data:")
-try:
-    events_fetched = my_new_calendar.search(
-        start=datetime(2021, 5, 16), end=datetime(2024, 1, 1), event=True, expand=True
+        ## Let's add some events to our newly created calendar
+        add_stuff_to_calendar_demo(my_new_calendar)
+
+        ## Let's find the stuff we just added to the calendar
+        event = search_calendar_demo(my_new_calendar)
+
+        ## Inspecting and modifying an event
+        read_modify_event_demo(event)
+
+        ## Accessing a calendar by a calendar URL
+        calendar_by_url_demo(client, my_new_calendar.url)
+
+        ## Clean up - delete things
+        ## (The event would normally be deleted together with the calendar,
+        ## but different calendar servers may behave differently ...)
+        event.delete()
+        my_new_calendar.delete()
+
+
+def calendar_by_url_demo(client, url):
+    """Sometimes one may have a calendar URL.  Sometimes maybe one would
+    not want to fetch the principal object from the server (it's not
+    even required to support it by the caldav protocol).
+    """
+    ## No network traffic will be initiated by this:
+    calendar = client.calendar(url=url)
+    ## At the other hand, this will cause network activity:
+    events = calendar.events()
+    ## We should still have only one event in the calendar
+    assert len(events) == 1
+
+    event_url = events[0].url
+
+    ## there is no similar method for fetching an event through
+    ## an URL.  One may construct the object like this though:
+    same_event = caldav.Event(client=client, parent=calendar, url=event_url)
+
+    ## That was also done without any network traffic.  To get the same_event
+    ## populated with data it needs to be loaded:
+    same_event.load()
+
+    assert same_event.data == events[0].data
+
+
+def read_modify_event_demo(event):
+    """
+    This demonstrates how to edit properties in the ical object and
+    save it back to the calendar
+    """
+    ## The objects (events, journals and tasks) comes with some properties that
+    ## can be used for inspecting the data and modifying it.
+
+    ## event.data is the raw data, as a string, with unix linebreaks
+    print("here comes some icalendar data:")
+    print(event.data)
+
+    ## event.wire_data is the raw data as a byte string with CRLN linebreaks
+    assert len(event.wire_data) >= len(event.data)
+
+    ## Two libraries exists to handle icalendar data - vobject and
+    ## icalendar.  The caldav library traditionally supported the
+    ## first one, but icalendar is more popular.
+
+    ## Here is an example
+    ## on how to modify the summary using vobject:
+    event.vobject_instance.vevent.summary.value = "norwegian national day celebratiuns"
+
+    ## event.icalendar_instance gives an icalendar instance - which
+    ## normally would be one icalendar calendar object containing one
+    ## subcomponent.  Quite often the fourth property,
+    ## icalendar_component is preferable - it gives us the component -
+    ## but be aware that if the server returns a recurring events with
+    ## exceptions, event.icalendar_component will ignore all the
+    ## exceptions.
+    uid = event.icalendar_component["uid"]
+
+    ## Let's correct that typo using the icalendar library.
+    event.icalendar_component["summary"] = event.icalendar_component["summary"].replace(
+        "celebratiuns", "celebrations"
     )
-    ## Note: obj.data will always return a normal string, with normal line breaks
-    ## obj.wire_data will return a byte string with CRLN
+
+    ## And finally, get the casing correct
+    event.data = event.data.replace("norwegian", "Norwegian")
+
+    ## Note that this is not quite thread-safe:
+    icalendar_component = event.icalendar_component
+    ## accessing the data (and setting it) will "disconnect" the
+    ## icalendar_component from the event
+    event.data = event.data
+    ## So this will not affect the event anymore:
+    icalendar_component["summary"] = "do the needful"
+    assert not "do the needful" in event.data
+
+    ## The mofifications are still only saved locally in memory -
+    ## let's save it to the server:
+    event.save()
+
+    ## NOTE: always use event.save() for updating events and
+    ## calendar.save_event(data) for creating a new event.
+    ## This may not break:
+    # event.save(event.data)
+    ## ref https://github.com/python-caldav/caldav/issues/153
+
+    ## Finally, let's verify that the correct data was saved
+    calendar = event.parent
+    same_event = calendar.event_by_uid(uid)
+    assert (
+        same_event.icalendar_component["summary"]
+        == "Norwegian national day celebrations"
+    )
+
+
+def search_calendar_demo(calendar):
+    """
+    some examples on how to fetch objects from the calendar
+    """
+    ## It should theoretically be possible to find both the events and
+    ## tasks in one calendar query, but not all server implementations
+    ## supports it, hence either event, todo or journal should be set
+    ## to True when searching.  Here is a date search for events, with
+    ## expand:
+    events_fetched = calendar.search(
+        start=datetime.now(),
+        end=datetime(date.today().year + 5, 1, 1),
+        event=True,
+        expand=True,
+    )
+
+    ## "expand" causes the recurrences to be expanded.
+    ## The yearly event will give us one object for each year
+    assert len(events_fetched) > 1
+
+    print("here is some ical data:")
     print(events_fetched[0].data)
-except:
-    print("Your calendar server does apparently not support expanded search")
-    events_fetched = my_new_calendar.search(
-        start=datetime(2020, 5, 16), end=datetime(2024, 1, 1), event=True, expand=False
+
+    ## We can also do the same thing without expand, then the "master"
+    ## from 2020 will be fetched
+    events_fetched = calendar.search(
+        start=datetime.now(),
+        end=datetime(date.today().year + 5, 1, 1),
+        event=True,
+        expand=False,
     )
-    print(events_fetched[0].data)
+    assert len(events_fetched) == 1
 
-event = events_fetched[0]
+    ## search can be done by other things, i.e. keyword
+    tasks_fetched = calendar.search(todo=True, category="outdoor")
+    assert len(tasks_fetched) == 1
 
-## To modify an event, it's best to use either the vobject or icalendar module for it.
-## The caldav library has always been supporting vobject out of the box, but icalendar is more popular.
-## event.instance will as of version 0.x yield a vobject instance, but this may change in future versions.
-## Both event.vobject_instance and event.icalendar_instance works from 0.7.
-event.vobject_instance.vevent.summary.value = "Norwegian national day celebratiuns"
-event.icalendar_instance.subcomponents[0][
-    "summary"
-] = event.icalendar_instance.subcomponents[0]["summary"].replace(
-    "celebratiuns", "celebrations"
-)
-event.save()
+    ## This those should also work:
+    all_objects = calendar.objects()
+    # updated_objects = calendar.objects_by_sync_token(some_sync_token)
+    # some_object = calendar.object_by_uid(some_uid)
+    # some_event = calendar.event_by_uid(some_uid)
+    children = calendar.children()
+    events = calendar.events()
+    tasks = calendar.todos()
+    assert len(events) + len(tasks) == len(all_objects)
+    assert len(children) == len(all_objects)
+    ## TODO: Some of those should probably be deprecated.
+    ## children is a good candidate.
 
-## Please note that the proper way to save new icalendar data
-## to the calendar is calendar.save_event(ics_data),
-## while the proper way to update a calendar event is
-## event.save().  Doing calendar.save_event(event.data)
-## may break.  See https://github.com/python-caldav/caldav/issues/153
-## for details.
+    ## Tasks can be completed
+    tasks[0].complete()
 
-## It's possible to access objects such as calendars without going
-## through a Principal object if one knows the calendar URL
-the_same_calendar = client.calendar(url=my_new_calendar.url)
+    ## They will then disappear from the task list
+    assert not calendar.todos()
 
-## to get all events from the calendar, it's also possible to use the
-## events()-method.  Recurring events will not be expanded.
-all_events = the_same_calendar.events()
+    ## But they are not deleted
+    assert len(calendar.todos(include_completed=True)) == 1
 
-## It's also possible to use .objects.
-all_objects = the_same_calendar.objects()
+    ## Let's delete it completely
+    tasks[0].delete()
 
-## since we have only added events (and neither todos nor journals), those
-## should be equal ... except, all_objects is an iterator and not a list.
-assert len(all_events) == len(list(all_objects))
+    return events_fetched[0]
 
-## Let's check that the summary got right
-assert all_events[0].vobject_instance.vevent.summary.value.startswith("Norwegian")
-assert all_events[0].vobject_instance.vevent.summary.value.endswith("celebrations")
 
-## This calendar should as a minimum support VEVENTs ... most likely
-## it also supports VTODOs and maybe even VJOURNALs.  We can query the
-## server what it can accept:
-acceptable_component_types = my_new_calendar.get_supported_components()
-assert "VEVENT" in acceptable_component_types
+def print_calendars_demo(calendars):
+    """
+    This example prints the name and URL for every calendar on the list
+    """
+    if calendars:
+        ## Some calendar servers will include all calendars you have
+        ## access to in this list, and not only the calendars owned by
+        ## this principal.
+        print("your principal has %i calendars:" % len(calendars))
+        for c in calendars:
+            print("    Name: %-36s  URL: %s" % (c.name, c.url))
+    else:
+        print("your principal has no calendars")
 
-## Clean up - remove the new calendar
-my_new_calendar.delete()
 
-## Let's try with a task list.  Some servers cannot combine events and todos in the same calendar.
-my_new_tasklist = my_principal.make_calendar(
-    name="Test tasklist", supported_calendar_component_set=["VTODO"]
-)
+def find_delete_calendar_demo(my_principal, calendar_name):
+    """
+    This example takes a calendar name, finds the calendar if it
+    exists, and deletes the calendar if it exists.
+    """
+    ## Let's try to find or create a calendar ...
+    try:
+        ## This will raise a NotFoundError if calendar does not exist
+        demo_calendar = my_principal.calendar(name="Test calendar from caldav examples")
+        assert demo_calendar
+        print(
+            f"We found an existing calendar with name {calendar_name}, now deleting it"
+        )
+        demo_calendar.delete()
+    except caldav.error.NotFoundError:
+        ## Calendar was not found
+        pass
 
-## We'll add a task to the task list
-my_new_tasklist.add_todo(
-    ics="RRULE:FREQ=YEARLY",
-    summary="Deliver some data to the Tax authorities",
-    dtstart=date(2020, 4, 1),
-    due=date(2020, 5, 1),
-    categories=["family", "finance"],
-    status="NEEDS-ACTION",
-)
 
-## Fetch the tasks
-todos = my_new_tasklist.todos()
-assert len(todos) == 1
-assert "FREQ=YEARLY" in todos[0].data
+def add_stuff_to_calendar_demo(calendar):
+    """
+    This demo adds some stuff to the calendar
 
-print("Here is some more icalendar data:")
-print(todos[0].data)
-
-## date_search also works on task lists, but one has to be explicit to get them
-todos_found = my_new_tasklist.search(
-    start=datetime(2021, 1, 1),
-    end=datetime(2024, 1, 1),
-    todo=True,
-    journal=True,
-    expand=True,
-)
-if not todos_found:
-    print(
-        "Apparently your calendar server does not support searching for future instances of reoccurring tasks"
+    Unfortunately the arguments that it's possible to pass to save_* is poorly documented.
+    https://github.com/python-caldav/caldav/issues/253
+    """
+    ## Add an event with some certain attributes
+    may_event = calendar.save_event(
+        dtstart=datetime(2020, 5, 17, 6),
+        dtend=datetime(2020, 5, 18, 1),
+        summary="Do the needful",
+        rrule={"FREQ": "YEARLY"},
     )
-else:
-    print("Here is even more icalendar data:")
-    print(todos_found[0].data)
 
-## Mark the task as completed
-todos[0].complete()
+    ## not all calendars supports tasks ... but if it's supported, it should be
+    ## told here:
+    acceptable_component_types = calendar.get_supported_components()
+    assert "VTODO" in acceptable_component_types
 
-## This is a yearly task.  Completing it for one year should probably
-## spawn a new task recurrence instance for the next year.  The RFC
-## says nothing about it, it seems like it's up to the clients weather
-## to implement such logic or not.  I've implemented such logic in the
-## calendar-cli project, perhaps it should be moved into the caldav
-## library, but as for now ... completing the task will cause the task
-## list to be emptied.
-todos = my_new_tasklist.todos()
-assert len(todos) == 0
+    ## Add a task that should contain some ical lines
+    ## Note that this may break on your server:
+    ## * not all servers accepts tasks and events mixed on the same calendar.
+    ## * not all servers accepts tasks at all
+    dec_task = calendar.save_todo(
+        ical_fragment="""DTSTART;VALUE=DATE:20201213
+DUE;VALUE=DATE:20201220
+SUMMARY:Chop down a tree and drag it into the living room
+RRULE:FREQ=YEARLY
+PRIORITY: 2
+CATEGORIES: outdoor"""
+    )
 
-## It's possible to fetch historic tasks too
-todos = my_new_tasklist.todos(include_completed=True)
-assert len(todos) == 1
+    ## ical_fragment parameter -> just some lines
+    ## ical parameter -> full ical object
 
-## and it's possible to delete tasks completely
-todos[0].delete()
 
-my_new_tasklist.delete()
+def _please_ignore_this_hack():
+    """
+    This hack is to be used for the maintainer (or other people
+    having set up testing servers in tests/private_conf.py) to be able
+    to verify that this example code works, without editing the
+    example code itself.
+    """
+    if password == "hunter2":
+        from tests.conf import client as client_
+
+        client = client_()
+
+        def _wrapper(*args, **kwargs):
+            return client
+
+        caldav.DAVClient = _wrapper
+
+
+if __name__ == "__main__":
+    _please_ignore_this_hack()
+    run_examples()

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -2235,8 +2235,6 @@ class RepeatedFunctionalTestsBaseClass(object):
 
 _servernames = set()
 for _caldav_server in caldav_servers:
-    if not _caldav_server.get("enable", True):
-        continue
     # create a unique identifier out of the server domain name
     _parsed_url = urlparse(_caldav_server["url"])
     _servername = _parsed_url.hostname.replace(".", "_").replace("-", "_") + str(


### PR DESCRIPTION
This is a collection of things that does not alter the caldav code itself:

* Version number pushed from 0.x to 1.0.  References #92,
* Comments in the code, docstrings, and minor changes to a deprecation warning.  Particularly TODO-comments and deprecation-comments.
* Deprecation-policy nailed in the doc.  Things that are marked as DEPRECATED by now *may* be removed in version 2.0.  Version 1.x will (most likely) be supported at least for 3 years, probably more.
* basic_usage_examples.py has been totally rewritten (and tested).
* Minor change in the test framework - checking for the `caldav_servers[i]["enable"]` attribute has been moved from test_caldav.py to conf.py (was needed for being able to test the basic_usage_examples.py.

(note: some minor bugfixes and enhancements were needed to the library to successfully test the basic_usage_examples.py - this will be committed in a separate pull request)