### PR TITLE
Bugfixings

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -155,6 +155,10 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
     ret = to_normal_str(my_instance.to_ical())
     if ical_fragment and ical_fragment.strip():
         ret = re.sub(
-            "^END:V", ical_fragment.strip() + "\nEND:V", ret, flags=re.MULTILINE
+            "^END:V",
+            ical_fragment.strip() + "\nEND:V",
+            ret,
+            flags=re.MULTILINE,
+            count=1,
         )
     return ret

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1604,6 +1604,9 @@ class SynchronizableCalendarObjectCollection(object):
     def __iter__(self):
         return self.objects.__iter__()
 
+    def __len__(self):
+        return len(self.objects)
+
     def objects_by_url(self):
         """
         returns a dict of the contents of the SynchronizableCalendarObjectCollection, URLs -> objects.

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -692,7 +692,10 @@ class Calendar(DAVObject):
             (isinstance(ical, str) or isinstance(ical, bytes))
             and not b"BEGIN:VCALENDAR" in to_wire(ical)
         ):
-            return vcal.create_ical(ical_fragment=ical, objtype=objtype, **ical_data)
+            ## TODO: the ical_fragment code is not much tested
+            if ical and not "ical_fragment" in ical_data:
+                ical_data["ical_fragment"] = ical
+            return vcal.create_ical(objtype=objtype, **ical_data)
         return ical
 
     ## TODO: consolidate save_* - too much code duplication here

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -134,6 +134,8 @@ if False:
         }
     )
 
+caldav_servers = [x for x in caldav_servers if x.get("enable", True)]
+
 ###################################################################
 # Convenience - get a DAVClient object from the caldav_servers list
 ###################################################################

--- a/tests/test_vcal.py
+++ b/tests/test_vcal.py
@@ -112,6 +112,7 @@ class TestVcal(TestCase):
             duration=timedelta(hours=5),
         )
         assert re.search(b"DTSTART(;VALUE=DATE-TIME)?:20321010T101010Z", some_ical)
+        assert some_ical.count(b"PRIORITY") == 1
 
         some_ical = create_and_validate(
             summary="gobledok",


### PR DESCRIPTION
Various minor fixes needed for the rewritten basic_usage_examples.py to work properly:

* Two bugfixes (and one extra line in the tests catching one of them) wrg of the possibility to create events or tasks based on some `ical_fragment`.  This seems not to have sufficient test code.  Hm.
* I think that `len(calendar.objects)` ought to work.  Apparently it didn't.