### PR TITLE
Bearer authentication support

### DIFF
--- a/caldav/requests.py
+++ b/caldav/requests.py
@@ -1,0 +1,16 @@
+from requests.auth import AuthBase
+
+
+class HTTPBearerAuth(AuthBase):
+    def __init__(self, password):
+        self.password = password
+
+    def __eq__(self, other):
+        return self.password == getattr(other, "password", None)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __call__(self, r):
+        r.headers["Authorization"] = f"Bearer {self.password}"
+        return r


### PR DESCRIPTION
This allows bearer token authentication when the caldav server announce supporting it in its `www-authenticate` header and a password is given. This fixes #119. In the end I did not added a `token` argument as I suggested there, and just reused `password` to store the token.

This is just a draft to check with you that I take the right direction.
What do you think?