### PR TITLE
DAViCal workarounds

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -131,6 +131,16 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         if not props.get("uid") and not "\nUID:" in (ical_fragment or ""):
             component.add("uid", uuid.uuid1())
         my_instance.add_component(component)
+        ## STATUS should default to NEEDS-ACTION for tasks, if it's not set
+        ## (otherwise we cannot easily add a task to a davical calendar and
+        ## then find it again - ref https://gitlab.com/davical-project/davical/-/issues/281
+        if (
+            not props.get("STATUS")
+            and not "\nSTATUS:" in (ical_fragment or "")
+            and objtype == "VTODO"
+        ):
+            props["STATUS"] = "NEEDS-ACTION"
+
     else:
         if not ical_fragment.strip().startswith("BEGIN:VCALENDAR"):
             ical_fragment = (
@@ -141,6 +151,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         my_instance = icalendar.Calendar.from_ical(ical_fragment)
         component = my_instance.subcomponents[0]
         ical_fragment = None
+
     for prop in props:
         if props[prop] is not None:
             if isinstance(props[prop], datetime.datetime) and not props[prop].tzinfo:


### PR DESCRIPTION
* STATUS should by default be set to NEEDS-ACTION.  Note that this only applies when no icalendar data is given.  NEEDS-ACTION is the implied default.  DAViCal needs it explicitly set, ref https://gitlab.com/davical-project/davical/-/issues/281