### PR TITLE
misc bugfixes

### DIFF
--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import vobject.icalendar
 
-__version__ = "1.0.1"
+__version__ = "1.0.2.dev0"
 
 from .davclient import DAVClient
 from .objects import *

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -128,7 +128,8 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
             objtype = "VEVENT"
         component = icalendar.cal.component_factory[objtype]()
         component.add("dtstamp", datetime.datetime.now(tz=datetime.timezone.utc))
-        component.add("uid", uuid.uuid1())
+        if not props.get("uid") and not "\nUID:" in (ical_fragment or ""):
+            component.add("uid", uuid.uuid1())
         my_instance.add_component(component)
     else:
         if not ical_fragment.strip().startswith("BEGIN:VCALENDAR"):

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -131,7 +131,7 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         component.add("uid", uuid.uuid1())
         my_instance.add_component(component)
     else:
-        if not ical_fragment.startswith("BEGIN:VCALENDAR"):
+        if not ical_fragment.strip().startswith("BEGIN:VCALENDAR"):
             ical_fragment = (
                 "BEGIN:VCALENDAR\n"
                 + to_normal_str(ical_fragment.strip())

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -2313,7 +2313,7 @@ class CalendarObjectResource(DAVObject):
             return i["DURATION"].dt
         elif "DTSTART" in i and self._ENDPARAM in i:
             return i[self._ENDPARAM].dt - i["DTSTART"].dt
-        elif "DTSTART" in i and not isinstance(i[DTSTART], datetime.datetime):
+        elif "DTSTART" in i and not isinstance(i["DTSTART"], datetime):
             return timedelta(days=1)
         else:
             return timedelta(0)

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1238,6 +1238,7 @@ class Calendar(DAVObject):
                 "summary",
                 "comment",
                 "class_",
+                "class",
                 "category",
                 "description",
                 "location",


### PR DESCRIPTION
* If a component was given with full ical (including the BEGIN:VCALENDAR-tag) but (a) leading blank(s), and some other field also was given, then the BEGIN/END:VCALENDAR tags got duplicated
* is-defined and is-not-defined search for class did not work
* New icalendar generation code: don't autogenerate a uuid if we already have an uuid
* Some exception got thrown in the get_duration-logic.

