### PR TITLE
Remove annoying assert from icalendar_component

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1806,7 +1806,7 @@ class CalendarObjectResource(DAVObject):
 
         self.save()
 
-    def _get_icalendar_component(self, assert_one=True):
+    def _get_icalendar_component(self, assert_one=False):
         """Returns the icalendar subcomponent - which should be an
         Event, Journal, Todo or FreeBusy from the icalendar class
 
@@ -1844,7 +1844,7 @@ class CalendarObjectResource(DAVObject):
     icalendar_component = property(
         _get_icalendar_component,
         _set_icalendar_component,
-        doc="icalendar component - cannot be used with recurrence sets",
+        doc="icalendar component - should not be used with recurrence sets",
     )
 
     def add_attendee(self, attendee, no_default_parameters=False, **parameters):


### PR DESCRIPTION
By default, the code would break with an ugly assert if doing `obj.icalendar_component` and the obj contained a recurrance set.  I think that in almost all cases it will be harmless to yield the first component in the recurrence set, and I'm pretty sure that assert will blow up things for people, so I change the default to not assert anything.

(maybe we should yield a rate-limited error message instead?)