### PR TITLE
Allow checking DUE on dependent before moving DUE

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -2615,7 +2615,7 @@ class Todo(CalendarObjectResource):
             * safe - see doc for _complete_recurring_safe for details
         """
         if not completion_timestamp:
-            completion_timestamp = datetime.utcnow().astimezone(vobject.icalendar.utc)
+            completion_timestamp = datetime.utcnow().astimezone(timezone.utc)
 
         if hasattr(self.instance.vtodo, "rrule") and handle_rrule:
             return getattr(self, "_complete_recurring_%s" % rrule_mode)(
@@ -2707,16 +2707,45 @@ class Todo(CalendarObjectResource):
         else:
             return None
 
-    def set_due(self, due, move_dtstart=False):
+    def set_due(self, due, move_dtstart=False, check_dependent=False):
         """The RFC specifies that a VTODO cannot have both due and
         duration, so when setting due, the duration field must be
         evicted
 
-        WARNING: this method is likely to be deprecated and moved to
-        the icalendar library.  If you decide to use it, please put
-        caldav<2.0 in the requirements.
+        check_dependent=True will raise some error if there exists a
+        parent calendar component (through RELATED-TO), and the parents
+        due or dtend is before the new dtend).
+
+        WARNING: this method is likely to be deprecated and parts of
+        it moved to the icalendar library.  If you decide to use it,
+        please put caldav<2.0 in the requirements.
+
+        WARNING: the check_dependent-logic may be rewritten to support
+        RFC9253 in 1.x already
         """
+        if hasattr(due, "tzinfo") and not due.tzinfo:
+            due = due.astimezone(timezone.utc)
         i = self.icalendar_component
+        if check_dependent:
+            rels = i.get("RELATED-TO")
+            if rels is None:
+                rels = []
+            if not isinstance(rels, list):
+                rels = [rels]
+            for rel in rels:
+                if rel.params.get("RELTYPE") == "PARENT":
+                    parent = self.parent.object_by_uid(rel)
+                    pend = parent.icalendar_component.get("DTEND")
+                    if pend:
+                        pend = pend.dt
+                    else:
+                        pend = parent.get_due()
+                    if pend and pend.astimezone(timezone.utc) < due:
+                        if check_dependent == "return":
+                            return parent
+                        raise error.ConsistencyError(
+                            "parent object has due/end %s, cannot procrastinate child object without first procrastinating parent object"
+                        )
         duration = self.get_duration()
         i.pop("DURATION", None)
         i.pop("DUE", None)


### PR DESCRIPTION
The flag check_dependent will check the RELATED-TO attribute and if there is some dependent ticket with a lower DUE, an error will be raised.

This feature was made for plann.