### PR TITLE
cal_obj.__str__ and cal_obj.__repr__ should be deterministic

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -350,13 +350,13 @@ class DAVObject(object):
         return self.get_property(dav.DisplayName())
 
     def __str__(self):
-        if dav.DisplayName.tag in self.props:
-            return self.props[dav.DisplayName.tag]
-        else:
+        try:
+            return str(self.get_property(dav.DisplayName(), use_cached=True)) or self.url
+        except:
             return str(self.url)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, str(self))
+        return "%s(%s)" % (self.__class__.__name__, self.url)
 
 
 class CalendarSet(DAVObject):

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -702,15 +702,18 @@ class RepeatedFunctionalTestsBaseClass(object):
         assert c.url is not None
         assert len(self.principal.calendars()) != 0
 
+        str_ = str(c)
+        repr_ = repr(c)
+
         ## Not sure if those asserts make much sense, the main point here is to exercise
         ## the __str__ and __repr__ methods on the Calendar object.
         if not self.check_compatibility_flag("no_displayname"):
             name = c.get_property(dav.DisplayName(), use_cached=True)
             if not name:
                 name = c.url
-        assert str(name) == str(c)
-        assert str(name) in repr(c)
+            assert str(name) == str_
         assert "Calendar" in repr(c)
+        assert str(c.url) in repr(c)
 
     def testProxy(self):
         if self.caldav.url.scheme == "https":


### PR DESCRIPTION
`__str__` will always return name (and may cause server traffic) while `__repr__` will show the URL (and will not cause server traffic - but will basically show everything needed to recreate the calendar object).

Earlier `__str__` would show name if it was available, otherwise URL, and would never initiate server traffic - and `__repr__` was calling `__str__`.