### PR TITLE
keep canonical URLs in synchronization objects

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1631,7 +1631,7 @@ class SynchronizableCalendarObjectCollection(object):
         if self._objects_by_url is None:
             self._objects_by_url = {}
             for obj in self:
-                self._objects_by_url[obj.url] = obj
+                self._objects_by_url[obj.url.canonical()] = obj
         return self._objects_by_url
 
     def sync(self):
@@ -1646,6 +1646,7 @@ class SynchronizableCalendarObjectCollection(object):
         )
         obu = self.objects_by_url()
         for obj in updates:
+            obj.url = obj.url.canonical()
             if (
                 obj.url in obu
                 and dav.GetEtag.tag in obu[obj.url].props


### PR DESCRIPTION
The test covering the synchronization code suddenly broke towards one of the servers; the URLs kept by the objects was non-deterministic, sometimes containing `:443` and sometimes not.  Now we're running `obj.url = obj.url.canonical()` to force through deterministic URLs and allow the tests to pass.