### PR TITLE
compatibility fix: objects returned by search should always be loaded

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1631,7 +1631,7 @@ class SynchronizableCalendarObjectCollection(object):
         if self._objects_by_url is None:
             self._objects_by_url = {}
             for obj in self:
-                self._objects_by_url[obj.url] = obj
+                self._objects_by_url[obj.url.canonical()] = obj
         return self._objects_by_url
 
     def sync(self):
@@ -1646,6 +1646,7 @@ class SynchronizableCalendarObjectCollection(object):
         )
         obu = self.objects_by_url()
         for obj in updates:
+            obj.url = obj.url.canonical()
             if (
                 obj.url in obu
                 and dav.GetEtag.tag in obu[obj.url].props

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1060,10 +1060,8 @@ class Calendar(DAVObject):
             end = kwargs["end"]
 
             for o in objects:
-                if not o.data:
-                    ## TODO: all objects here should have data, unless the calendar server is breaking the caldav standard.
-                    ## Perhaps we should load missing data?
-                    continue
+                ## This should not be needed
+                o.load(only_if_unloaded=True)
                 component = o.icalendar_component
                 recurrance_properties = ["exdate", "exrule", "rdate", "rrule"]
                 if any(key in component for key in recurrance_properties):
@@ -1812,8 +1810,7 @@ class CalendarObjectResource(DAVObject):
 
         See also https://github.com/python-caldav/caldav/issues/232
         """
-        if not self.is_loaded():
-            self.load()
+        self.load(only_if_unloaded=True)
         ret = [
             x
             for x in self.icalendar_instance.subcomponents
@@ -1915,8 +1912,7 @@ class CalendarObjectResource(DAVObject):
         ievent.add("attendee", attendee_obj)
 
     def is_invite_request(self):
-        if not self.data:
-            self.load()
+        self.load(only_if_unloaded=True)
         return self.icalendar_instance.get("method", None) == "REQUEST"
 
     def accept_invite(self, calendar=None):
@@ -2187,7 +2183,7 @@ class CalendarObjectResource(DAVObject):
         return self
 
     def is_loaded(self):
-        return self._data or self._vobject_instance or self._icalendar_instance
+        return (self._data or self._vobject_instance or self._icalendar_instance) and self.data.count('BEGIN:')>1
 
     def __str__(self):
         return "%s: %s" % (self.__class__.__name__, self.url)

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -348,10 +348,12 @@ class TestCalDAV:
             "http://cal.example.com/home/bernard/calendars/"
         )
 
-    def testDateSearch(self):
+    @mock.patch("caldav.CalendarObjectResource.is_loaded")
+    def testDateSearch(self, mocked):
         """
         ## ref https://github.com/python-caldav/caldav/issues/133
         """
+        mocked.__bool__ = lambda self: True
         xml = """<xml><multistatus xmlns="DAV:">
 <response>
     <href>/principals/calendar/home@petroski.example.com/963/43B060B3-A023-48ED-B9E7-6FFD38D5073E.ics</href>
@@ -401,7 +403,7 @@ class TestCalDAV:
         calendar = Calendar(
             client, url="/principals/calendar/home@petroski.example.com/963/"
         )
-        results = calendar.date_search(datetime(2021, 2, 1), datetime(2021, 2, 7))
+        results = calendar.date_search(datetime(2021, 2, 1), datetime(2021, 2, 7), expand=False)
         assert len(results) == 3
 
     def testCalendar(self):


### PR DESCRIPTION
Some test broke towards some server because the server threw empty icalendar objects back at us - objects containing `BEGIN:VCALENDAR` and `END:VCALENDAR` and a little bit of metadata, but no components.  This was working out earlier while the `vobjects` library was used to determinate if client-side expansion was needed or not, but when changing to `obj.icalendar_component` we got an assertion error back.  Now the code is changed so that search items that have no data *or* no components to them will be loaded.   This may cause very much longer loading times, but the decision was sort of made in 1.0.1 already - this will happen only on a few calendar servers that are breaching the RFC.

Also cleaned a bit up/refactored, to always use the new `.load(only_if_unloaded=True)` rather than having the `if not obj.data:`-logic.