### PR TITLE
fix log message : argument was bytes not String

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -70,7 +70,7 @@ class DAVResponse:
                 except:
                     logging.critical(
                         "Expected some valid XML from the server, but got this: \n"
-                        + self._raw,
+                        + str(self._raw),
                         exc_info=True,
                     )
                     raise


### PR DESCRIPTION
Fix logger, error message was :

```
  File "/home/arnaud/.local/lib/python3.10/site-packages/caldav/davclient.py", line 77, in __init__
    "Expected some valid XML from the server, but got this: \n"
TypeError: can only concatenate str (not "bytes") to str
```
