### PR TITLE
Unpack id when populating all calendar list

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -382,7 +382,14 @@ class CalendarSet(DAVObject):
 
         data = self.children(cdav.Calendar.tag)
         for c_url, c_type, c_name in data:
-            cals.append(Calendar(self.client, c_url, parent=self, name=c_name))
+            try:
+                cal_id = c_url.split("/")[-2]
+            except:
+                log.error(f"Calendar {c_name} has unexpected url {c_url}")
+                cal_id = None
+            cals.append(
+                Calendar(self.client, id=cal_id, url=c_url, parent=self, name=c_name)
+            )
 
         return cals
 


### PR DESCRIPTION
To address #313: lack of ID field populating in "all calendar" request.  I included fall-back in case the URL isn't as I expect.