### PR TITLE
set_related: allow custom types with set_reversed=False

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -31,7 +31,7 @@ except ImportError:
     from urllib import unquote, quote
 
 try:
-    from typing import Union, Optional
+    from typing import ClassVar, Union, Optional
 
     TimeStamp = Optional[Union[date, datetime]]
 except:
@@ -1709,6 +1709,12 @@ class CalendarObjectResource(DAVObject):
     event, a todo-item, a journal entry, or a free/busy entry
     """
 
+    RELTYPE_REVERSER: ClassVar = {
+        "PARENT": "CHILD",
+        "CHILD": "PARENT",
+        "SIBLING": "SIBLING",
+    }
+
     _ENDPARAM = None
 
     _vobject_instance = None
@@ -1811,9 +1817,7 @@ class CalendarObjectResource(DAVObject):
         """
         ##TODO: test coverage
         reltype = reltype.upper()
-        reltype_reverse = {"CHILD": "PARENT", "PARENT": "CHILD", "SIBLING": "SIBLING"}[
-            reltype
-        ]
+        reltype_reverse = self.RELTYPE_REVERSER[reltype]
         if isinstance(other, CalendarObjectResource):
             if other.id:
                 uid = other.id

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1817,7 +1817,6 @@ class CalendarObjectResource(DAVObject):
         """
         ##TODO: test coverage
         reltype = reltype.upper()
-        reltype_reverse = self.RELTYPE_REVERSER[reltype]
         if isinstance(other, CalendarObjectResource):
             if other.id:
                 uid = other.id
@@ -1828,6 +1827,7 @@ class CalendarObjectResource(DAVObject):
             if set_reverse:
                 other = self.parent.object_by_uid(uid)
         if set_reverse:
+            reltype_reverse = self.RELTYPE_REVERSER[reltype]
             other.set_relation(other=self, reltype=reltype_reverse, set_reverse=False)
 
         existing_relation = self.icalendar_component.get("related-to", None)


### PR DESCRIPTION
Method failed before when using a custom relation type. Specification explicitly allows custom X-Types for non-standardized use cases. This also makes the library future-proof if futher relation types are added.

Also extract RELTYPE_REVERSER constant from method for good practice.

Tested for my use case (using a custom type) locally.