### PR TITLE
Prevent infinite recursion when querying

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -202,7 +202,7 @@ class DAVObject(object):
         ) or ret.status >= 400:
             ## COMPATIBILITY HACK - see https://github.com/python-caldav/caldav/issues/309
             body = to_wire(body)
-            if ret.status == 500 and not b"getetag" in body:
+            if ret.status == 500 and not b"getetag" in body and b"<C:calendar-data/>" in body:
                 body = body.replace(
                     b"<C:calendar-data/>", b"<D:getetag/><C:calendar-data/>"
                 )


### PR DESCRIPTION
An infinite recursion could occur when the server responded with an error code 500 and the body of the request did not contain the binary string "<C:calendar-data/>".

Now the application checks that this binary string is present.

This PR should fix #343.