### PR TITLE
Initialize stamped and ended, implementing the small optimization todo

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -121,6 +121,11 @@ class LineFilterDiscardingDuplicates:
     This must be called line by line in order on the complete text, at
     least comprising the complete vobject.
     """
+
+    def __init__(self):
+        self.stamped = 0
+        self.ended = 0
+
     def __call__(self, line):
         if line.startswith("BEGIN:V"):
             self.stamped = 0

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -131,12 +131,12 @@ class LineFilterDiscardingDuplicates:
             self.stamped = 0
             self.ended = 0
 
-        elif re.search("^(DURATION|DTEND|DUE)[:;]", line):
+        elif re.match("(DURATION|DTEND|DUE)[:;]", line):
             if self.ended:
                 return False
             self.ended += 1
 
-        elif line.startswith("DTSTAMP") and line[7] in (";", ":"):
+        elif re.match("DTSTAMP[:;]", line):
             if self.stamped:
                 return False
             self.stamped += 1


### PR DESCRIPTION
The lack of initialization of the `stamped` variable was causing a failure from an unexpected place when running it with a faulty ical that lacked a `BEGIN:V…` before having the first `DTSTAMP`. Probably the same with `ended`. Only affects bad strings, so it’s more of an error handling improvement…