### PR TITLE
Add example in test for stamped initialization issue from #347

### DIFF
--- a/tests/test_vcal.py
+++ b/tests/test_vcal.py
@@ -149,7 +149,17 @@ UID:1c9bba3e-c121-11ed-bf96-982cbcdd642c
 CATEGORIES:oslo
 END:VEVENT
 END:VCALENDAR
-"""
+""",
+            ## Next one contains a DTSTAMP before BEGIN:VEVENT
+            ## Doesn’t make sense, but valid, and more importantly,
+            ## not failing during the `fix` call.
+            """DTSTAMP:20210205T101751Z
+BEGIN:VEVENT
+UID:20200516T060000Z-123401@example.com
+SUMMARY:Do the needful
+DTSTART:20210517T060000Z
+END:VEVENT
+""",
         ]
         broken_ical = [
             ## This first one contains duplicated DTSTAMP in the event data


### PR DESCRIPTION
The pull request #347 didn’t contain a test that showed the difference, so here it is. Without the fix, the test would’ve failed like:

```python
…
            for ical in non_broken_ical:                                            
>               assert vcal.fix(ical) == ical

tests/test_vcal.py:262:                                                             
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
caldav/lib/vcal.py:81: in fix             
    "\n".join(filter(LineFilterDiscardingDuplicates(), fixed.strip().split("\n")))  
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
                                          
self = <caldav.lib.vcal.LineFilterDiscardingDuplicates object at 0x7a99fd022820>    
line = 'DTSTAMP:20210205T101751Z'                                                   
                                                                                    
    def __call__(self, line):                                                       
        if line.startswith("BEGIN:V"):                                              
            self.stamped = 0                                                                                                                                            
            self.ended = 0                                                          
                                                                                    
        elif re.match("(DURATION|DTEND|DUE)[:;]", line):
            if self.ended:
                return False
            self.ended += 1
                                          
        elif re.match("DTSTAMP[:;]", line):
>           if self.stamped:
E           AttributeError: 'LineFilterDiscardingDuplicates' object has no attribute 'stamped'

caldav/lib/vcal.py:141: AttributeError
```