### PR TITLE
Add inline typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This project should more or less adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [x.x.x] - unreleased
+
+* Initial work at integrating typing information. Details in https://github.com/python-caldav/caldav/pull/358
+
 ## [1.3.9] - 2023-12-12
 
 Some bugfixes.

--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -18,7 +18,7 @@ log = logging.getLogger("caldav")
 
 
 class NullHandler(logging.Handler):
-    def emit(self, record):
+    def emit(self, record) -> None:
         pass
 
 

--- a/caldav/elements/base.py
+++ b/caldav/elements/base.py
@@ -1,18 +1,35 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+import sys
+import typing
+from typing import ClassVar
+from typing import List
+from typing import Optional
+from typing import Union
+
 from caldav.lib.namespace import nsmap
 from caldav.lib.python_utilities import to_unicode
 from lxml import etree
+from lxml.etree import _Element
+from typing_extensions import Self
+from typing_extensions import TypeAlias
+
+if sys.version_info < (3, 9):
+    from typing import Iterable
+else:
+    from collections.abc import Iterable
 
 
-class BaseElement(object):
-    children = None
-    tag = None
-    value = None
-    attributes = None
+class BaseElement:
+    children: Optional[List[Self]] = None
+    tag: ClassVar[Optional[str]] = None
+    value: Optional[str] = None
+    attributes: typing.Optional[dict] = None
     caldav_class = None
 
-    def __init__(self, name=None, value=None):
+    def __init__(
+        self, name: Optional[str] = None, value: Union[str, bytes, None] = None
+    ) -> None:
         self.children = []
         self.attributes = {}
         value = to_unicode(value)
@@ -22,16 +39,24 @@ class BaseElement(object):
         if value is not None:
             self.value = value
 
-    def __add__(self, other):
+    def __add__(
+        self, other: Union["BaseElement", Iterable["BaseElement"]]
+    ) -> "BaseElement":
         return self.append(other)
 
-    def __str__(self):
+    def __str__(self) -> str:
         utf8 = etree.tostring(
             self.xmlelement(), encoding="utf-8", xml_declaration=True, pretty_print=True
         )
         return str(utf8, "utf-8")
 
-    def xmlelement(self):
+    def xmlelement(self) -> _Element:
+        if self.tag is None:
+            raise ValueError("Unexpected value None for self.tag")
+
+        if self.attributes is None:
+            raise ValueError("Unexpected value None for self.attributes")
+
         root = etree.Element(self.tag, nsmap=nsmap)
         if self.value is not None:
             root.text = self.value
@@ -41,21 +66,27 @@ class BaseElement(object):
         self.xmlchildren(root)
         return root
 
-    def xmlchildren(self, root):
+    def xmlchildren(self, root: _Element) -> None:
+        if self.children is None:
+            raise ValueError("Unexpected value None for self.children")
+
         for c in self.children:
             root.append(c.xmlelement())
 
-    def append(self, element):
-        try:
-            iter(element)
+    def append(self, element: Union[Self, Iterable[Self]]) -> Self:
+        if self.children is None:
+            raise ValueError("Unexpected value None for self.children")
+
+        if isinstance(element, Iterable):
             self.children.extend(element)
-        except TypeError:
+        else:
             self.children.append(element)
+
         return self
 
 
 class NamedBaseElement(BaseElement):
-    def __init__(self, name=None):
+    def __init__(self, name: Optional[str] = None) -> None:
         super(NamedBaseElement, self).__init__(name=name)
 
     def xmlelement(self):
@@ -65,5 +96,5 @@ class NamedBaseElement(BaseElement):
 
 
 class ValuedBaseElement(BaseElement):
-    def __init__(self, value=None):
+    def __init__(self, value: Union[str, bytes, None] = None) -> None:
         super(ValuedBaseElement, self).__init__(value=value)

--- a/caldav/elements/cdav.py
+++ b/caldav/elements/cdav.py
@@ -2,6 +2,12 @@
 # -*- encoding: utf-8 -*-
 import logging
 from datetime import datetime
+from typing import ClassVar
+from typing import Optional
+
+from .base import BaseElement
+from .base import NamedBaseElement
+from .base import ValuedBaseElement
 
 try:
     from datetime import timezone
@@ -55,64 +61,74 @@ def _to_utc_date_string(ts):
 
 # Operations
 class CalendarQuery(BaseElement):
-    tag = ns("C", "calendar-query")
+    tag: ClassVar[str] = ns("C", "calendar-query")
 
 
 class FreeBusyQuery(BaseElement):
-    tag = ns("C", "free-busy-query")
+    tag: ClassVar[str] = ns("C", "free-busy-query")
 
 
 class Mkcalendar(BaseElement):
-    tag = ns("C", "mkcalendar")
+    tag: ClassVar[str] = ns("C", "mkcalendar")
 
 
 class CalendarMultiGet(BaseElement):
-    tag = ns("C", "calendar-multiget")
+    tag: ClassVar[str] = ns("C", "calendar-multiget")
 
 
 class ScheduleInboxURL(BaseElement):
-    tag = ns("C", "schedule-inbox-URL")
+    tag: ClassVar[str] = ns("C", "schedule-inbox-URL")
 
 
 class ScheduleOutboxURL(BaseElement):
-    tag = ns("C", "schedule-outbox-URL")
+    tag: ClassVar[str] = ns("C", "schedule-outbox-URL")
 
 
 # Filters
 class Filter(BaseElement):
-    tag = ns("C", "filter")
+    tag: ClassVar[str] = ns("C", "filter")
 
 
 class CompFilter(NamedBaseElement):
-    tag = ns("C", "comp-filter")
+    tag: ClassVar[str] = ns("C", "comp-filter")
 
 
 class PropFilter(NamedBaseElement):
-    tag = ns("C", "prop-filter")
+    tag: ClassVar[str] = ns("C", "prop-filter")
 
 
 class ParamFilter(NamedBaseElement):
-    tag = ns("C", "param-filter")
+    tag: ClassVar[str] = ns("C", "param-filter")
 
 
 # Conditions
 class TextMatch(ValuedBaseElement):
-    tag = ns("C", "text-match")
+    tag: ClassVar[str] = ns("C", "text-match")
 
-    def __init__(self, value, collation="i;octet", negate=False):
+    def __init__(self, value, collation: str = "i;octet", negate: bool = False) -> None:
         super(TextMatch, self).__init__(value=value)
+
+        if self.attributes is None:
+            raise ValueError("Unexpected value None for self.attributes")
+
         self.attributes["collation"] = collation
         if negate:
             self.attributes["negate-condition"] = "yes"
 
 
 class TimeRange(BaseElement):
-    tag = ns("C", "time-range")
+    tag: ClassVar[str] = ns("C", "time-range")
 
-    def __init__(self, start=None, end=None):
+    def __init__(
+        self, start: Optional[datetime] = None, end: Optional[datetime] = None
+    ) -> None:
         ## start and end should be an icalendar "date with UTC time",
         ## ref https://tools.ietf.org/html/rfc4791#section-9.9
         super(TimeRange, self).__init__()
+
+        if self.attributes is None:
+            raise ValueError("Unexpected value None for self.attributes")
+
         if start is not None:
             self.attributes["start"] = _to_utc_date_string(start)
         if end is not None:
@@ -120,19 +136,25 @@ class TimeRange(BaseElement):
 
 
 class NotDefined(BaseElement):
-    tag = ns("C", "is-not-defined")
+    tag: ClassVar[str] = ns("C", "is-not-defined")
 
 
 # Components / Data
 class CalendarData(BaseElement):
-    tag = ns("C", "calendar-data")
+    tag: ClassVar[str] = ns("C", "calendar-data")
 
 
 class Expand(BaseElement):
-    tag = ns("C", "expand")
+    tag: ClassVar[str] = ns("C", "expand")
 
-    def __init__(self, start, end=None):
+    def __init__(
+        self, start: Optional[datetime], end: Optional[datetime] = None
+    ) -> None:
         super(Expand, self).__init__()
+
+        if self.attributes is None:
+            raise ValueError("Unexpected value None for self.attributes")
+
         if start is not None:
             self.attributes["start"] = _to_utc_date_string(start)
         if end is not None:
@@ -140,7 +162,7 @@ class Expand(BaseElement):
 
 
 class Comp(NamedBaseElement):
-    tag = ns("C", "comp")
+    tag: ClassVar[str] = ns("C", "comp")
 
 
 # Uhhm ... can't find any references to calendar-collection in rfc4791.txt
@@ -152,61 +174,61 @@ class Comp(NamedBaseElement):
 
 # Properties
 class CalendarUserAddressSet(BaseElement):
-    tag = ns("C", "calendar-user-address-set")
+    tag: ClassVar[str] = ns("C", "calendar-user-address-set")
 
 
 class CalendarUserType(BaseElement):
-    tag = ns("C", "calendar-user-type")
+    tag: ClassVar[str] = ns("C", "calendar-user-type")
 
 
 class CalendarHomeSet(BaseElement):
-    tag = ns("C", "calendar-home-set")
+    tag: ClassVar[str] = ns("C", "calendar-home-set")
 
 
 # calendar resource type, see rfc4791, sec. 4.2
 class Calendar(BaseElement):
-    tag = ns("C", "calendar")
+    tag: ClassVar[str] = ns("C", "calendar")
 
 
 class CalendarDescription(ValuedBaseElement):
-    tag = ns("C", "calendar-description")
+    tag: ClassVar[str] = ns("C", "calendar-description")
 
 
 class CalendarTimeZone(ValuedBaseElement):
-    tag = ns("C", "calendar-timezone")
+    tag: ClassVar[str] = ns("C", "calendar-timezone")
 
 
 class SupportedCalendarComponentSet(ValuedBaseElement):
-    tag = ns("C", "supported-calendar-component-set")
+    tag: ClassVar[str] = ns("C", "supported-calendar-component-set")
 
 
 class SupportedCalendarData(ValuedBaseElement):
-    tag = ns("C", "supported-calendar-data")
+    tag: ClassVar[str] = ns("C", "supported-calendar-data")
 
 
 class MaxResourceSize(ValuedBaseElement):
-    tag = ns("C", "max-resource-size")
+    tag: ClassVar[str] = ns("C", "max-resource-size")
 
 
 class MinDateTime(ValuedBaseElement):
-    tag = ns("C", "min-date-time")
+    tag: ClassVar[str] = ns("C", "min-date-time")
 
 
 class MaxDateTime(ValuedBaseElement):
-    tag = ns("C", "max-date-time")
+    tag: ClassVar[str] = ns("C", "max-date-time")
 
 
 class MaxInstances(ValuedBaseElement):
-    tag = ns("C", "max-instances")
+    tag: ClassVar[str] = ns("C", "max-instances")
 
 
 class MaxAttendeesPerInstance(ValuedBaseElement):
-    tag = ns("C", "max-attendees-per-instance")
+    tag: ClassVar[str] = ns("C", "max-attendees-per-instance")
 
 
 class Allprop(BaseElement):
-    tag = ns("C", "allprop")
+    tag: ClassVar[str] = ns("C", "allprop")
 
 
 class ScheduleTag(BaseElement):
-    tag = ns("C", "schedule-tag")
+    tag: ClassVar[str] = ns("C", "schedule-tag")

--- a/caldav/elements/dav.py
+++ b/caldav/elements/dav.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+from typing import ClassVar
+
 from caldav.lib.namespace import ns
 
 from .base import BaseElement
@@ -8,62 +10,62 @@ from .base import ValuedBaseElement
 
 # Operations
 class Propfind(BaseElement):
-    tag = ns("D", "propfind")
+    tag: ClassVar[str] = ns("D", "propfind")
 
 
 class PropertyUpdate(BaseElement):
-    tag = ns("D", "propertyupdate")
+    tag: ClassVar[str] = ns("D", "propertyupdate")
 
 
 class Mkcol(BaseElement):
-    tag = ns("D", "mkcol")
+    tag: ClassVar[str] = ns("D", "mkcol")
 
 
 class SyncCollection(BaseElement):
-    tag = ns("D", "sync-collection")
+    tag: ClassVar[str] = ns("D", "sync-collection")
 
 
 # Filters
 
 # Conditions
 class SyncToken(BaseElement):
-    tag = ns("D", "sync-token")
+    tag: ClassVar[str] = ns("D", "sync-token")
 
 
 class SyncLevel(BaseElement):
-    tag = ns("D", "sync-level")
+    tag: ClassVar[str] = ns("D", "sync-level")
 
 
 # Components / Data
 
 
 class Prop(BaseElement):
-    tag = ns("D", "prop")
+    tag: ClassVar[str] = ns("D", "prop")
 
 
 class Collection(BaseElement):
-    tag = ns("D", "collection")
+    tag: ClassVar[str] = ns("D", "collection")
 
 
 class Set(BaseElement):
-    tag = ns("D", "set")
+    tag: ClassVar[str] = ns("D", "set")
 
 
 # Properties
 class ResourceType(BaseElement):
-    tag = ns("D", "resourcetype")
+    tag: ClassVar[str] = ns("D", "resourcetype")
 
 
 class DisplayName(ValuedBaseElement):
-    tag = ns("D", "displayname")
+    tag: ClassVar[str] = ns("D", "displayname")
 
 
 class GetEtag(ValuedBaseElement):
-    tag = ns("D", "getetag")
+    tag: ClassVar[str] = ns("D", "getetag")
 
 
 class Href(BaseElement):
-    tag = ns("D", "href")
+    tag: ClassVar[str] = ns("D", "href")
 
 
 class SupportedReportSet(BaseElement):
@@ -71,28 +73,28 @@ class SupportedReportSet(BaseElement):
 
 
 class Response(BaseElement):
-    tag = ns("D", "response")
+    tag: ClassVar[str] = ns("D", "response")
 
 
 class Status(BaseElement):
-    tag = ns("D", "status")
+    tag: ClassVar[str] = ns("D", "status")
 
 
 class PropStat(BaseElement):
-    tag = ns("D", "propstat")
+    tag: ClassVar[str] = ns("D", "propstat")
 
 
 class MultiStatus(BaseElement):
-    tag = ns("D", "multistatus")
+    tag: ClassVar[str] = ns("D", "multistatus")
 
 
 class CurrentUserPrincipal(BaseElement):
-    tag = ns("D", "current-user-principal")
+    tag: ClassVar[str] = ns("D", "current-user-principal")
 
 
 class PrincipalCollectionSet(BaseElement):
-    tag = ns("D", "principal-collection-set")
+    tag: ClassVar[str] = ns("D", "principal-collection-set")
 
 
 class Allprop(BaseElement):
-    tag = ns("D", "allprop")
+    tag: ClassVar[str] = ns("D", "allprop")

--- a/caldav/elements/ical.py
+++ b/caldav/elements/ical.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+from typing import ClassVar
+
 from caldav.lib.namespace import ns
 
 from .base import BaseElement
@@ -7,8 +9,8 @@ from .base import ValuedBaseElement
 
 # Properties
 class CalendarColor(ValuedBaseElement):
-    tag = ns("I", "calendar-color")
+    tag: ClassVar[str] = ns("I", "calendar-color")
 
 
 class CalendarOrder(ValuedBaseElement):
-    tag = ns("I", "calendar-order")
+    tag: ClassVar[str] = ns("I", "calendar-order")

--- a/caldav/lib/debug.py
+++ b/caldav/lib/debug.py
@@ -7,5 +7,5 @@ def xmlstring(root):
     return etree.tostring(root, pretty_print=True).decode("utf-8")
 
 
-def printxml(root):
+def printxml(root) -> None:
     print(xmlstring(root))

--- a/caldav/lib/error.py
+++ b/caldav/lib/error.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 import logging
+import typing
 from collections import defaultdict
+from typing import Optional
 
 from caldav import __version__
 
@@ -23,7 +25,7 @@ else:
     log.setLevel(logging.WARNING)
 
 
-def assert_(condition):
+def assert_(condition: object) -> None:
     try:
         assert condition
     except AssertionError:
@@ -40,20 +42,20 @@ def assert_(condition):
             raise
 
 
-ERR_FRAGMENT = "Please raise an issue at https://github.com/python-caldav/caldav/issues or reach out to t-caldav@tobixen.no, include this error and the traceback and tell what server you are using"
+ERR_FRAGMENT: str = "Please raise an issue at https://github.com/python-caldav/caldav/issues or reach out to t-caldav@tobixen.no, include this error and the traceback and tell what server you are using"
 
 
 class DAVError(Exception):
-    url = None
-    reason = "no reason"
+    url: Optional[str] = None
+    reason: str = "no reason"
 
-    def __init__(self, url=None, reason=None):
+    def __init__(self, url: Optional[str] = None, reason: Optional[str] = None) -> None:
         if url:
             self.url = url
         if reason:
             self.reason = reason
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s at '%s', reason %s" % (
             self.__class__.__name__,
             self.url,
@@ -115,7 +117,9 @@ class ResponseError(DAVError):
     pass
 
 
-exception_by_method = defaultdict(lambda: DAVError)
+exception_by_method: typing.Dict[str, typing.Type[DAVError]] = defaultdict(
+    lambda: DAVError
+)
 for method in (
     "delete",
     "put",

--- a/caldav/lib/namespace.py
+++ b/caldav/lib/namespace.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+import typing
+from typing import Dict
+from typing import Optional
 
-nsmap = {
+nsmap: Dict[str, str] = {
     "D": "DAV:",
     "C": "urn:ietf:params:xml:ns:caldav",
 }
@@ -11,11 +14,11 @@ nsmap = {
 ## calendar-color and calendar-order properties.  However, those
 ## attributes aren't described anywhere, and the I-URL even gives a
 ## 404!  I don't want to ship it in the namespace list of every request.
-nsmap2 = nsmap.copy()
+nsmap2: Dict[str, typing.Any] = nsmap.copy()
 nsmap2["I"] = ("http://apple.com/ns/ical/",)
 
 
-def ns(prefix, tag=None):
+def ns(prefix: str, tag: Optional[str] = None) -> str:
     name = "{%s}" % nsmap2[prefix]
     if tag is not None:
         name = "%s%s" % (name, tag)

--- a/caldav/lib/url.py
+++ b/caldav/lib/url.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+import typing
+import urllib.parse
+from typing import Union
 from urllib.parse import ParseResult
 from urllib.parse import quote
 from urllib.parse import SplitResult
@@ -9,6 +12,7 @@ from urllib.parse import urlunparse
 
 from caldav.lib.python_utilities import to_normal_str
 from caldav.lib.python_utilities import to_unicode
+from typing_extensions import Self
 
 
 class URL:
@@ -41,24 +45,24 @@ class URL:
 
     """
 
-    def __init__(self, url):
+    def __init__(self, url: Union[str, ParseResult, SplitResult]) -> None:
         if isinstance(url, ParseResult) or isinstance(url, SplitResult):
-            self.url_parsed = url
+            self.url_parsed: typing.Optional[Union[ParseResult, SplitResult]] = url
             self.url_raw = None
         else:
             self.url_raw = url
             self.url_parsed = None
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         if self.url_raw or self.url_parsed:
             return True
         else:
             return False
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if str(self) == str(other):
             return True
         # The URLs could have insignificant differences
@@ -67,13 +71,13 @@ class URL:
             other = other.canonical()
         return str(me) == str(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(str(self))
 
     # TODO: better naming?  Will return url if url is already a URL
     # object, else will instantiate a new URL object
     @classmethod
-    def objectify(self, url):
+    def objectify(self, url: Union[Self, str, ParseResult, SplitResult]) -> "URL":
         if url is None:
             return None
         if isinstance(url, URL):
@@ -83,39 +87,44 @@ class URL:
 
     # To deal with all kind of methods/properties in the ParseResult
     # class
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str):
         if "url_parsed" not in vars(self):
             raise AttributeError
         if self.url_parsed is None:
-            self.url_parsed = urlparse(self.url_raw)
+            self.url_parsed = typing.cast(
+                urllib.parse.ParseResult, urlparse(self.url_raw)
+            )
         if hasattr(self.url_parsed, attr):
             return getattr(self.url_parsed, attr)
         else:
             return getattr(self.__unicode__(), attr)
 
     # returns the url in text format
-    def __str__(self):
+    def __str__(self) -> str:
         return to_normal_str(self.__unicode__())
 
     # returns the url in text format
-    def __unicode__(self):
+    def __unicode__(self) -> str:
         if self.url_raw is None:
+            if self.url_parsed is None:
+                raise ValueError("Unexpected value None for self.url_parsed")
+
             self.url_raw = self.url_parsed.geturl()
         return to_unicode(self.url_raw)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "URL(%s)" % str(self)
 
-    def strip_trailing_slash(self):
+    def strip_trailing_slash(self) -> "URL":
         if str(self)[-1] == "/":
             return URL.objectify(str(self)[:-1])
         else:
             return self
 
-    def is_auth(self):
+    def is_auth(self) -> bool:
         return self.username is not None
 
-    def unauth(self):
+    def unauth(self) -> "URL":
         if not self.is_auth():
             return self
         return URL.objectify(
@@ -130,7 +139,7 @@ class URL:
             )
         )
 
-    def canonical(self):
+    def canonical(self) -> "URL":
         """
         a canonical URL ... remove authentication details, make sure there
         are no double slashes, and to make sure the URL is always the same,
@@ -138,7 +147,7 @@ class URL:
         """
         url = self.unauth()
 
-        arr = list(self.url_parsed)
+        arr = list(typing.cast(urllib.parse.ParseResult, self.url_parsed))
         ## quoting path and removing double slashes
         arr[2] = quote(unquote(url.path.replace("//", "/")))
         ## sensible defaults
@@ -159,7 +168,7 @@ class URL:
 
         return url
 
-    def join(self, path):
+    def join(self, path: typing.Any) -> "URL":
         """
         assumes this object is the base URL or base path.  If the path
         is relative, it should be appended to the base.  If the path
@@ -197,6 +206,6 @@ class URL:
         )
 
 
-def make(url):
+def make(url: Union[URL, str, ParseResult, SplitResult]) -> URL:
     """Backward compatibility"""
     return URL.objectify(url)

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -122,7 +122,7 @@ class LineFilterDiscardingDuplicates:
     least comprising the complete vobject.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.stamped = 0
         self.ended = 0
 

--- a/caldav/requests.py
+++ b/caldav/requests.py
@@ -2,13 +2,13 @@ from requests.auth import AuthBase
 
 
 class HTTPBearerAuth(AuthBase):
-    def __init__(self, password):
+    def __init__(self, password: str) -> None:
         self.password = password
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self.password == getattr(other, "password", None)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
     def __call__(self, r):

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ if __name__ == "__main__":
             "requests",
             "icalendar",
             "recurring-ical-events>=2.0.0",
+            "typing_extensions",
         ]
         + extra_packages,
         extras_require={

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1542,11 +1542,11 @@ class RepeatedFunctionalTestsBaseClass(object):
         foo = parent_.get_relatives(reltypes={"PARENT"})
         assert len(foo) == 1
         assert len(foo["PARENT"]) == 1
-        assert [foo["PARENT"][0].icalendar_component["UID"] == grandparent.id]
+        assert [list(foo["PARENT"])[0].icalendar_component["UID"] == grandparent.id]
         foo = parent_.get_relatives(reltypes={"CHILD"})
         assert len(foo) == 1
         assert len(foo["CHILD"]) == 1
-        assert [foo["CHILD"][0].icalendar_component["UID"] == child.id]
+        assert [list(foo["CHILD"])[0].icalendar_component["UID"] == child.id]
         foo = parent_.get_relatives(reltypes={"CHILD", "PARENT"})
         assert len(foo) == 2
         assert len(foo["CHILD"]) == 1


### PR DESCRIPTION
This fixes #328 by inlining type hints from typeshed caldav. Types were later fixed and further implemented where missing.

Tests all pass using Xandikos. davical was also tested, here 3 tests fail which also fail with the current master:
- testSearchEvent
- testTodoDatesearch
- testInviteAndRespond

I tried as much as possible not to touch any actual code, besides adding "None" checks. No logic was changed.

Types were verified using typeguard (pytest extension).
Also pre-commit hooks were run.

Could you please have a look and let me know if there is anything left to do for this to get merged ?