### PR TITLE
Remove dependency on pytz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project should more or less adhere to [Semantic Versioning](https://semver.
 ## [x.x.x] - unreleased
 
 * Initial work at integrating typing information. Details in https://github.com/python-caldav/caldav/pull/358
+* Remove dependency on pytz. Details in https://github.com/python-caldav/caldav/issues/231
 
 ## [1.3.9] - 2023-12-12
 

--- a/caldav/elements/cdav.py
+++ b/caldav/elements/cdav.py
@@ -2,26 +2,17 @@
 # -*- encoding: utf-8 -*-
 import logging
 from datetime import datetime
+from datetime import timezone
 from typing import ClassVar
 from typing import Optional
+
+from caldav.lib.namespace import ns
 
 from .base import BaseElement
 from .base import NamedBaseElement
 from .base import ValuedBaseElement
 
-try:
-    from datetime import timezone
-
-    utc_tz = timezone.utc
-except:
-    ## pytz is deprecated - but as of 2021-11, the icalendar library is only
-    ## compatible with pytz (see https://github.com/collective/icalendar/issues/333 https://github.com/collective/icalendar/issues/335 https://github.com/collective/icalendar/issues/336)
-    import pytz
-
-    utc_tz = pytz.utc
-
-from caldav.lib.namespace import ns
-from .base import BaseElement, NamedBaseElement, ValuedBaseElement
+utc_tz = timezone.utc
 
 
 def _to_utc_date_string(ts):

--- a/examples/scheduling_examples.py
+++ b/examples/scheduling_examples.py
@@ -2,12 +2,13 @@ import sys
 import uuid
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
-import pytz
 from caldav import DAVClient
 from caldav import error
 from icalendar import Calendar
 from icalendar import Event
+
 
 ###############
 ### SETUP START
@@ -218,8 +219,8 @@ import pdb
 
 pdb.set_trace()
 some_data_returned = organizer.principal.freebusy_request(
-    dtstart=datetime.now().astimezone(pytz.utc) + timedelta(days=399),
-    dtend=datetime.now().astimezone(pytz.utc) + timedelta(days=399, hours=1),
+    dtstart=datetime.now().astimezone(timezone.utc) + timedelta(days=399),
+    dtend=datetime.now().astimezone(timezone.utc) + timedelta(days=399, hours=1),
     attendees=[attendee1.principal, attendee2.principal],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -24,24 +24,6 @@ with open("caldav/__init__.py", "rb") as f:
     )
 
 if __name__ == "__main__":
-    ## For python 2.7 and 3.5 we depend on pytz and tzlocal.  For 3.6 and up, batteries are included.  Same with mock. (But unfortunately the icalendar library only support pytz timezones, so we'll keep pytz around for a bit longer).
-    try:
-        import datetime
-        from datetime import timezone
-
-        datetime.datetime.now().astimezone(timezone.utc)
-        extra_packages = []
-        ## line below can be removed when https://github.com/collective/icalendar/issues/333 is fixed
-        extra_packages = ["pytz", "tzlocal"]
-    except:
-        extra_packages = ["pytz", "tzlocal"]
-    try:
-        from unittest.mock import MagicMock
-
-        extra_test_packages = []
-    except:
-        extra_test_packages = ["mock"]
-
     ## TODO: consider if automated testing with radicale in addition to
     ## xandikos would yield any benefits.
     test_packages = [
@@ -49,13 +31,12 @@ if __name__ == "__main__":
         "pytest-coverage",
         "coverage",
         "sphinx",
+        "backports.zoneinfo;python_version<'3.9'",
+        "tzlocal",
+        "xandikos==0.2.8;python_version<'3.9'",
+        "dulwich==0.20.50;python_version<'3.9'",
+        "xandikos;python_version>='3.9'",
     ]
-
-    if sys.version_info.major == 3 and sys.version_info.minor < 9:
-        test_packages.append("xandikos==0.2.8")
-        test_packages.append("dulwich==0.20.50")
-    else:
-        test_packages.append("xandikos")
 
     setup(
         name="caldav",
@@ -90,8 +71,7 @@ if __name__ == "__main__":
             "icalendar",
             "recurring-ical-events>=2.0.0",
             "typing_extensions",
-        ]
-        + extra_packages,
+        ],
         extras_require={
             "test": test_packages,
         },

--- a/tests/test_cdav.py
+++ b/tests/test_cdav.py
@@ -1,11 +1,15 @@
 import datetime
 
-import pytz
 import tzlocal
 from caldav.elements.cdav import _to_utc_date_string
 from caldav.elements.cdav import CalendarQuery
 
-SOMEWHERE_REMOTE = pytz.timezone("Brazil/DeNoronha")  # UTC-2 and no DST
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
+SOMEWHERE_REMOTE = zoneinfo.ZoneInfo("Brazil/DeNoronha")  # UTC-2 and no DST
 
 
 def test_element():
@@ -32,9 +36,9 @@ def test_to_utc_date_string_utc():
     assert res == "20190514T211023Z"
 
 
-def test_to_utc_date_string_dt_with_pytz_tzinfo():
-    input = datetime.datetime(2019, 5, 14, 21, 10, 23, 23)
-    res = _to_utc_date_string(SOMEWHERE_REMOTE.localize(input))
+def test_to_utc_date_string_dt_with_zoneinfo_tzinfo():
+    input = datetime.datetime(2019, 5, 14, 21, 10, 23, 23, tzinfo=SOMEWHERE_REMOTE)
+    res = _to_utc_date_string(input)
     assert res == "20190514T231023Z"
 
 

--- a/tests/test_vcal.py
+++ b/tests/test_vcal.py
@@ -3,11 +3,11 @@ import re
 import uuid
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from unittest import TestCase
 
 import icalendar
 import pytest
-import pytz
 import vobject
 from caldav.lib import vcal
 from caldav.lib.python_utilities import to_normal_str
@@ -15,9 +15,7 @@ from caldav.lib.python_utilities import to_wire
 from caldav.lib.vcal import create_ical
 from caldav.lib.vcal import fix
 
-# from datetime import timezone
-# utc = timezone.utc
-utc = pytz.utc
+utc = timezone.utc
 
 # example from http://www.rfc-editor.org/rfc/rfc5545.txt
 ev = """BEGIN:VCALENDAR


### PR DESCRIPTION
- Removed dependency on pytz
- kept tzlocal only for testing
- added backports.zoneinfo in case of <py3.9 for tests


fixes #231