### PR TITLE
fix: google may return empty ical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ This project should more or less adhere to [Semantic Versioning](https://semver.
 * Georges Toth (@sim0nx) did a lot of efforts lifting up the project to more modern standards.
 * A hook for collecting debug information has been in the pull request for ages.  I've decided to include it in 1.4.0.
 * Code formatting / style fixes.
+* Search method did some logic handling non-conformant servers (loading data from the server if the search response didn't include the icalendar data, ignoring trash from the Google server when it returns data without a VTODO/VEVENT/VJOURNAL component.
+
+### Fixed
+
+* Revisited a problem that Google sometimes delivers junk when doing searches - credits to github user @zhwei in https://github.com/python-caldav/caldav/pull/366
+* There were some compatibility-logic loading objects if the server does not deliver icalendar data (as it's suppsoed to do according to the RFC), but only if passing the `expand`-flag to the `search`-method.  Fixed that it loads regardless of weather `expand` is set or not.  Also in https://github.com/python-caldav/caldav/pull/366
+
+### Changed
+
+* In https://github.com/python-caldav/caldav/pull/366, I optimized the logic in `search` a bit, now all data from the server not containing a VEVENT, VTODO or VJOURNAL will be thrown away.  I believe this won't cause any problems for anyone, as the server should only deliver such components, but I may be wrong.
 
 ### Added
 

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -1248,6 +1248,9 @@ class Calendar(DAVObject):
                 objects = []
                 for o in objects_:
                     objects.extend(o.split_expanded())
+        else:
+            ## Google sometimes returns empty objects
+            objects = [o for o in objects if o.icalendar_component]
 
         def sort_key_func(x):
             ret = []

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -350,12 +350,14 @@ class TestCalDAV:
             "http://cal.example.com/home/bernard/calendars/"
         )
 
-    @mock.patch("caldav.objects.CalendarObjectResource.is_loaded")
-    def testDateSearch(self, mocked):
+    def _load(self, only_if_unloaded=True):
+        self.data = todo6
+
+    @mock.patch("caldav.objects.CalendarObjectResource.load", new=_load)
+    def testDateSearch(self):
         """
         ## ref https://github.com/python-caldav/caldav/issues/133
         """
-        mocked.__bool__ = lambda self: True
         xml = """<xml><multistatus xmlns="DAV:">
 <response>
     <href>/principals/calendar/home@petroski.example.com/963/43B060B3-A023-48ED-B9E7-6FFD38D5073E.ics</href>


### PR DESCRIPTION
something like:

```
BEGIN:VCALENDAR
PRODID:-//Google Inc//Google Calendar 70.9054//EN
VERSION:2.0
CALSCALE:GREGORIAN
X-WR-CALNAME:TEST
X-WR-TIMEZONE:Asia/Shanghai
BEGIN:VTIMEZONE
TZID:Asia/Shanghai
X-LIC-LOCATION:Asia/Shanghai
BEGIN:STANDARD
TZOFFSETFROM:+0800
TZOFFSETTO:+0800
TZNAME:CST
DTSTART:19700101T000000
END:STANDARD
END:VTIMEZONE
END:VCALENDAR
```