### PR TITLE
Make it possible to modify User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project should more or less adhere to [Semantic Versioning](https://semver.
 ### Fixed
 
 * Code formatting / style fixes.
+* Jason Yau introduced the possibility to add arbitrary headers - but things like User-Agent would anyway always be overwritten.  Now the custom logic takes precedence.  Pull request https://github.com/python-caldav/caldav/pull/386, issue https://github.com/python-caldav/caldav/issues/385
 * Search method did some logic handling non-conformant servers (loading data from the server if the search response didn't include the icalendar data, ignoring trash from the Google server when it returns data without a VTODO/VEVENT/VJOURNAL component.
 * Revisited a problem that Google sometimes delivers junk when doing searches - credits to github user @zhwei in https://github.com/python-caldav/caldav/pull/366
 * There were some compatibility-logic loading objects if the server does not deliver icalendar data (as it's suppsoed to do according to the RFC), but only if passing the `expand`-flag to the `search`-method.  Fixed that it loads regardless of weather `expand` is set or not.  Also in https://github.com/python-caldav/caldav/pull/366

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -409,14 +409,12 @@ class DAVClient:
             self.proxy = _proxy
 
         # Build global headers
-        self.headers = headers
-        self.headers.update(
-            {
-                "User-Agent": "Mozilla/5.0",
-                "Content-Type": "text/xml",
-                "Accept": "text/xml, text/calendar",
-            }
-        )
+        self.headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Content-Type": "text/xml",
+            "Accept": "text/xml, text/calendar",
+        }
+        self.headers.update(headers)
         if self.url.username is not None:
             username = unquote(self.url.username)
             password = unquote(self.url.password)

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1297,9 +1297,9 @@ class RepeatedFunctionalTestsBaseClass(object):
                 start=datetime(2006, 7, 13, 13, 0),
                 end=datetime(2006, 7, 15, 13, 0),
             )
-            if (not self.check_compatibility_flag(
+            if not self.check_compatibility_flag(
                 "category_search_yields_nothing"
-            ) and not self.check_compatibility_flag("combined_search_not_working")):
+            ) and not self.check_compatibility_flag("combined_search_not_working"):
                 assert len(no_events) == 0
             some_events = c.search(
                 comp_class=Event,

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -272,9 +272,14 @@ class TestCalDAV:
         mocked().status_code = 200
         mocked().headers = {}
         cal_url = "http://me:hunter2@calendar.møøh.example:80/"
-        client = DAVClient(url=cal_url, headers={"X-NC-CalDAV-Webcal-Caching": "On"})
+        client = DAVClient(
+            url=cal_url,
+            headers={"X-NC-CalDAV-Webcal-Caching": "On", "User-Agent": "MyCaldavApp"},
+        )
         assert client.headers["Content-Type"] == "text/xml"
         assert client.headers["X-NC-CalDAV-Webcal-Caching"] == "On"
+        ## User-Agent would be overwritten by some boring default in earlier versions
+        assert client.headers["User-Agent"] == "MyCaldavApp"
 
     @mock.patch("caldav.davclient.requests.Session.request")
     def testEmptyXMLNoContentLength(self, mocked):


### PR DESCRIPTION
see also #385

Also, the previous code had a dangerous usage of a default `{}` sent as function parameter.  I didn't change it, but at least now the dict passed is a read-only thing.

We need some test code and a changelog item before this can be merged.