### PR TITLE
Partial revert of 075841971b603bbe5774880ee1fa6abf778b84b0

### DIFF
--- a/caldav/__init__.py
+++ b/caldav/__init__.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
         "You need to install the `build` package and do a `python -m build` to get caldav.__version__ set correctly"
     )
 from .davclient import DAVClient
+from .objects import *  ## This should go away in version 2.0.  TODO: fix some system for deprecation notices
 
 # Silence notification of no default logging handler
 log = logging.getLogger("caldav")

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1297,9 +1297,9 @@ class RepeatedFunctionalTestsBaseClass(object):
                 start=datetime(2006, 7, 13, 13, 0),
                 end=datetime(2006, 7, 15, 13, 0),
             )
-            if (not self.check_compatibility_flag(
+            if not self.check_compatibility_flag(
                 "category_search_yields_nothing"
-            ) and not self.check_compatibility_flag("combined_search_not_working")):
+            ) and not self.check_compatibility_flag("combined_search_not_working"):
                 assert len(no_events) == 0
             some_events = c.search(
                 comp_class=Event,


### PR DESCRIPTION
An "import *" was removed in above commit.  Yes, "import *" is bad practice - but since those things are reimported other places, we can't remove it in a minor release.  First we need some kind of deprecation notice, then we need to remove it when doing a major release.  I aim for every major release to be backward compatible with everything that wasn't marked as deprecated in the previous x.0.0 major release, so 3.0 is the earliest we can remove this.