### PR TITLE
CHange default User-Agent from Mozilla/5 to python-caldav/$version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project should more or less adhere to [Semantic Versioning](https://semver.
 ### Changed
 
 * In https://github.com/python-caldav/caldav/pull/366, I optimized the logic in `search` a bit, now all data from the server not containing a VEVENT, VTODO or VJOURNAL will be thrown away.  I believe this won't cause any problems for anyone, as the server should only deliver such components, but I may be wrong.
+* Default User-Agent changed from `Mozilla/5` to `python-caldav/{__version__}`
 
 ### Added
 

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -20,6 +20,7 @@ from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 
 from .elements.base import BaseElement
+from caldav import __version__
 from caldav.elements import dav
 from caldav.lib import error
 from caldav.lib.python_utilities import to_normal_str
@@ -421,7 +422,7 @@ class DAVClient:
 
         # Build global headers
         self.headers = {
-            "User-Agent": "Mozilla/5.0",
+            "User-Agent": "python-caldav/" + __version__,
             "Content-Type": "text/xml",
             "Accept": "text/xml, text/calendar",
         }

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -276,6 +276,7 @@ class TestCalDAV:
     def testRequestCustomHeaders(self, mocked):
         """
         ref https://github.com/python-caldav/caldav/issues/285
+        also ref https://github.com/python-caldav/caldav/issues/385
         """
         mocked().status_code = 200
         mocked().headers = {}
@@ -288,6 +289,20 @@ class TestCalDAV:
         assert client.headers["X-NC-CalDAV-Webcal-Caching"] == "On"
         ## User-Agent would be overwritten by some boring default in earlier versions
         assert client.headers["User-Agent"] == "MyCaldavApp"
+
+    @mock.patch("caldav.davclient.requests.Session.request")
+    def testRequestUserAgent(self, mocked):
+        """
+        ref https://github.com/python-caldav/caldav/issues/391
+        """
+        mocked().status_code = 200
+        mocked().headers = {}
+        cal_url = "http://me:hunter2@calendar.møøh.example:80/"
+        client = DAVClient(
+            url=cal_url,
+        )
+        assert client.headers["Content-Type"] == "text/xml"
+        assert client.headers["User-Agent"].startswith("python-caldav/")
 
     @mock.patch("caldav.davclient.requests.Session.request")
     def testEmptyXMLNoContentLength(self, mocked):


### PR DESCRIPTION
Resolves https://github.com/python-caldav/caldav/issues/391