### PR TITLE
Remove unused dep pytest-cov.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest",
-    "pytest-coverage",
     "coverage",
     "sphinx",
     "backports.zoneinfo;python_version<'3.9'",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py37,py38,py39,py310,py311,py312,docs,style
 
 [testenv]
 deps = --editable .[test]
-commands = pytest {posargs:--cov}
+commands = coverage run -m pytest
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
Coverage fully support test coverage. Pytest cov not used.