### PR TITLE
RFC/WIP: adopt ruff and its code upgrade/format methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,13 @@
 ---
 repos:
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.12.0
-    hooks:
-      - id: reorder-python-imports
-  - repo: https://github.com/psf/black
-    rev: 23.12.0
-    hooks:
-      - id: black
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
-      - id: check-byte-order-marker
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.7
+  hooks:
+    - id: ruff
+    - id: ruff-format
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+    - id: check-byte-order-marker
+    - id: trailing-whitespace
+    - id: end-of-file-fixer

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -646,9 +646,7 @@ class DAVClient:
             log.debug("using proxy - %s" % (proxies))
 
         log.debug(
-            "sending request - method={0}, url={1}, headers={2}\nbody:\n{3}".format(
-                method, str(url_obj), combined_headers, to_normal_str(body)
-            )
+            f"sending request - method={method}, url={str(url_obj)}, headers={combined_headers}\nbody:\n{to_normal_str(body)}"
         )
 
         try:
@@ -756,16 +754,16 @@ class DAVClient:
 
             with NamedTemporaryFile(prefix="caldavcomm", delete=False) as commlog:
                 commlog.write(b"=" * 80 + b"\n")
-                commlog.write(f"{datetime.datetime.now():%FT%H:%M:%S}".encode("utf-8"))
+                commlog.write(f"{datetime.datetime.now():%FT%H:%M:%S}".encode())
                 commlog.write(b"\n====>\n")
-                commlog.write(f"{method} {url}\n".encode("utf-8"))
+                commlog.write(f"{method} {url}\n".encode())
                 commlog.write(
                     b"\n".join(to_wire(f"{x}: {headers[x]}") for x in headers)
                 )
                 commlog.write(b"\n\n")
                 commlog.write(to_wire(body))
                 commlog.write(b"<====\n")
-                commlog.write(f"{response.status} {response.reason}".encode("utf-8"))
+                commlog.write(f"{response.status} {response.reason}".encode())
                 commlog.write(
                     b"\n".join(
                         to_wire(f"{x}: {response.headers[x]}") for x in response.headers

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -7,6 +7,7 @@ caldav server, notably principal, calendars and calendar events.
 release.  I think it makes sense moving the CalendarObjectResource
 class hierarchy into a separate file)
 """
+
 import re
 import sys
 import uuid
@@ -63,7 +64,8 @@ if TYPE_CHECKING:
 if sys.version_info < (3, 9):
     from typing import Callable, Container, Iterable, Iterator, Sequence
 
-    from typing_extensions import DefaultDict, Literal
+    from typing_extensions import Literal
+    from typing import DefaultDict
 else:
     from collections import defaultdict as DefaultDict
     from collections.abc import Callable, Container, Iterable, Iterator, Sequence
@@ -2535,9 +2537,7 @@ class CalendarObjectResource(DAVObject):
             or (self._icalendar_instance and self.icalendar_component)
         ) and self.data.count("BEGIN:VEVENT") + self.data.count(
             "BEGIN:VTODO"
-        ) + self.data.count(
-            "BEGIN:VJOURNAL"
-        ) > 0
+        ) + self.data.count("BEGIN:VJOURNAL") > 0
 
     def __str__(self) -> str:
         return "%s: %s" % (self.__class__.__name__, self.url)
@@ -2827,7 +2827,7 @@ class Todo(CalendarObjectResource):
             rrule = i["RRULE"]
         if not dtstart:
             if by is True or (
-                by is None and any((x for x in rrule if x.startswith("BY")))
+                by is None and any(x for x in rrule if x.startswith("BY"))
             ):
                 if "DTSTART" in i:
                     dtstart = i["DTSTART"].dt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # python-caldav documentation build configuration file, created by
 # sphinx-quickstart on Thu Jun  3 10:47:52 2010.

--- a/examples/basic_usage_examples.py
+++ b/examples/basic_usage_examples.py
@@ -168,7 +168,7 @@ def read_modify_event_demo(event):
     event.data = event.data
     ## So this will not affect the event anymore:
     icalendar_component["summary"] = "do the needful"
-    assert not "do the needful" in event.data
+    assert "do the needful" not in event.data
 
     ## The mofifications are still only saved locally in memory -
     ## let's save it to the server:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ dependencies = [
     "typing_extensions;python_version<'3.11'",
 ]
 dynamic = ["version"]
-
+requires-python = ">=3.8"
 [project.optional-dependencies]
 test = [
     "pytest",
@@ -58,3 +57,6 @@ include-package-data = true
 [tool.setuptools.packages.find]
 exclude = ["tests"]
 namespaces = false
+
+[tool.ruff.lint]
+extend-select = ["UP"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import setuptools
 
 setuptools.setup()

--- a/tests/_test_absolute.py
+++ b/tests/_test_absolute.py
@@ -1,10 +1,9 @@
-# encoding: utf-8
 import datetime
 
 import caldav
 
 
-class TestRadicale(object):
+class TestRadicale:
     SUMMARIES = set(
         (
             "Godspeed You! Black Emperor at " "Cirque Royal / Koninklijk Circus",
@@ -35,7 +34,7 @@ class TestRadicale(object):
         assert dtstart == self.DTSTART
 
 
-class TestTryton(object):
+class TestTryton:
     def setup(self):
         URL = "http://admin:admin@localhost:9080/caldav/Calendars/Test"
         self.client = caldav.DAVClient(URL)

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 ## YOU SHOULD MOST LIKELY NOT EDIT THIS FILE!
 ## Make a conf_private.py for personal configuration.
 ## Check conf_private.py.EXAMPLE
@@ -46,8 +45,6 @@ try:
     from .conf_private import test_xandikos
 except ImportError:
     try:
-        import xandikos
-
         test_xandikos = True
     except:
         test_xandikos = False
@@ -62,8 +59,6 @@ try:
     from .conf_private import test_radicale
 except ImportError:
     try:
-        import radicale
-
         test_radicale = True
     except:
         test_radicale = False
@@ -160,7 +155,7 @@ def client(idx=None, **kwargs):
         if bad_param in kwargs:
             kwargs.pop(bad_param)
     for kw in kwargs:
-        if not kw in CONNKEYS:
+        if kw not in CONNKEYS:
             logging.critical(
                 "unknown keyword %s in connection parameters.  All compatibility flags should now be sent as a separate list, see conf_private.py.EXAMPLE.  Ignoring."
                 % kw

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -13,6 +13,7 @@ Any help will be greatly appreciated.       SUZUKI Hisao
              * Added custom logging methods
              * Added code to make this a standalone application
 """
+
 import ftplib
 import getopt
 import logging.handlers
@@ -28,7 +29,6 @@ from socketserver import ThreadingMixIn
 from time import sleep
 from types import CodeType
 from types import FrameType
-from urllib import parse
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
@@ -68,7 +68,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
         )
         try:
             soc.connect(host_port)
-        except socket.error as arg:
+        except OSError as arg:
             try:
                 msg = arg[1]
             except:
@@ -248,7 +248,7 @@ def handler(signo, frame):
 
 
 def daemonize(logger):
-    class DevNull(object):
+    class DevNull:
         def __init__(self):
             self.fd = os.open("/dev/null", os.O_WRONLY)
 
@@ -361,7 +361,7 @@ def main():
                     threading.activeCount(),
                 )
                 req_count = 0
-        except select.error as e:
+        except OSError as e:
             if e[0] == 4 and run_event.isSet():
                 pass
             else:

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 """
 Tests here communicate with third party servers and/or
 internal ad-hoc instances of Xandikos and Radicale, dependent on the
@@ -7,15 +6,14 @@ configuration in conf_private.py.
 Tests that do not require communication with a working caldav server
 belong in test_caldav_unit.py
 """
+
 import codecs
 import logging
 import random
-import sys
 import tempfile
 import threading
 import time
 import uuid
-from collections import namedtuple
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
@@ -40,18 +38,12 @@ from .conf import xandikos_host
 from .conf import xandikos_port
 from .proxy import NonThreadingHTTPServer
 from .proxy import ProxyHandler
-from caldav.davclient import DAVClient
-from caldav.davclient import DAVResponse
 from caldav.elements import cdav
 from caldav.elements import dav
 from caldav.elements import ical
 from caldav.lib import error
-from caldav.lib import url
 from caldav.lib.python_utilities import to_local
 from caldav.lib.python_utilities import to_str
-from caldav.lib.url import URL
-from caldav.objects import Calendar
-from caldav.objects import CalendarSet
 from caldav.objects import DAVObject
 from caldav.objects import Event
 from caldav.objects import FreeBusy
@@ -353,7 +345,7 @@ sched = sched_template % (
     len(rfc6638_users) < 3,
     reason="need at least three users in rfc6638_users to be set in order to run this test",
 )
-class TestScheduling(object):
+class TestScheduling:
     """Testing support of RFC6638.
     TODO: work in progress.  Stalled a bit due to lack of proper testing accounts.  I haven't managed to get this test to pass at any systems yet, but I believe the problem is not on the library side.
     * icloud: cannot really test much with only one test account
@@ -433,7 +425,7 @@ class TestScheduling(object):
         ## principals[1] should have one new inbox item
         new_inbox_items = []
         for item in self.principals[1].schedule_inbox().get_items():
-            if not item.url in inbox_items:
+            if item.url not in inbox_items:
                 new_inbox_items.append(item)
         assert len(new_inbox_items) == 1
         ## ... and the new inbox item should be an invite request
@@ -449,7 +441,7 @@ class TestScheduling(object):
         ## calendar invite was accepted
         new_inbox_items = []
         for item in self.principals[0].schedule_inbox().get_items():
-            if not item.url in inbox_items:
+            if item.url not in inbox_items:
                 new_inbox_items.append(item)
         assert len(new_inbox_items) == 1
         assert new_inbox_items[0].is_invite_reply()
@@ -466,7 +458,7 @@ class TestScheduling(object):
     ## inbox/outbox?
 
 
-class RepeatedFunctionalTestsBaseClass(object):
+class RepeatedFunctionalTestsBaseClass:
     """This is a class with functional tests (tests that goes through
     basic functionality and actively communicates with third parties)
     that we want to repeat for all configured caldav_servers.
@@ -1076,7 +1068,7 @@ class RepeatedFunctionalTestsBaseClass(object):
         if not self.check_compatibility_flag("fragile_sync_tokens"):
             assert len(list(updated)) == 0
             assert len(list(deleted)) == 1
-        assert not obj.url in my_objects.objects_by_url()
+        assert obj.url not in my_objects.objects_by_url()
 
         if self.check_compatibility_flag("time_based_sync_tokens"):
             time.sleep(1)
@@ -1493,7 +1485,7 @@ class RepeatedFunctionalTestsBaseClass(object):
 
     def testWrongPassword(self):
         if (
-            not "password" in self.server_params
+            "password" not in self.server_params
             or not self.server_params["password"]
             or self.server_params["password"] == "any-password-seems-to-work"
         ):

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 """
 Rule: None of the tests in this file should initiate any internet
 communication, and there should be no dependencies on a working caldav
 server for the tests in this file.  We use the Mock class when needed
 to emulate server communication.
 """
+
 import pickle
 from datetime import date
 from datetime import datetime
@@ -16,15 +16,11 @@ from urllib.parse import urlparse
 import icalendar
 import lxml.etree
 import pytest
-import vobject
 
-import caldav
 from caldav import Calendar
 from caldav import CalendarObjectResource
 from caldav import CalendarSet
-from caldav import DAVObject
 from caldav import Event
-from caldav import FreeBusy
 from caldav import Journal
 from caldav import Principal
 from caldav import Todo
@@ -32,9 +28,7 @@ from caldav.davclient import DAVClient
 from caldav.davclient import DAVResponse
 from caldav.elements import cdav
 from caldav.elements import dav
-from caldav.elements import ical
 from caldav.lib import error
-from caldav.lib import url
 from caldav.lib.python_utilities import to_normal_str
 from caldav.lib.python_utilities import to_wire
 from caldav.lib.url import URL
@@ -199,7 +193,7 @@ class TestExpandRRule:
             start=datetime(1998, 10, 10), end=datetime(1998, 12, 12)
         )
         assert len(self.yearly.icalendar_instance.subcomponents) == 1
-        assert not "RRULE" in self.yearly.icalendar_component
+        assert "RRULE" not in self.yearly.icalendar_component
         assert "UID" in self.yearly.icalendar_component
         assert "RECURRENCE-ID" in self.yearly.icalendar_component
 
@@ -265,8 +259,8 @@ class TestCalDAV:
         assert response.tree is None
 
         response = client.put(
-            "/foo/møøh/bar".encode("utf-8"),
-            "bringebærsyltetøy 北京 пиво".encode("utf-8"),
+            "/foo/møøh/bar".encode(),
+            "bringebærsyltetøy 北京 пиво".encode(),
             {},
         )
         assert response.status == 200
@@ -297,7 +291,8 @@ class TestCalDAV:
         mocked().status_code = 200
         mocked().headers = {"Content-Type": "text/xml"}
         mocked().content = ""
-        client = DAVClient(url="AsdfasDF").request("/")
+        client = DAVClient(url="AsdfasDF")
+        client.request("/")
 
     @mock.patch("caldav.davclient.requests.Session.request")
     def testNonValidXMLNoContentLength(self, mocked):
@@ -976,11 +971,8 @@ END:VCALENDAR
         #    assert type(e) == lxml.etree.XMLSyntaxError
 
         davclient.huge_tree = True
-        try:
-            DAVResponse(resp, davclient=davclient)
-            assert True
-        except:
-            assert False
+
+        DAVResponse(resp, davclient=davclient)
 
     def testFailedQuery(self):
         """
@@ -1251,16 +1243,11 @@ END:VCALENDAR
                 )
             )
         )
-        # print(filter)
+        print(filter)
 
         crash = cdav.CompFilter()
-        value = None
-        try:
-            value = str(crash)
-        except:
-            pass
-        if value is not None:
-            raise Exception("This should have crashed")
+        with pytest.raises(Exception, match="name attribute must be defined"):
+            str(crash)
 
     def test_calendar_comp_class_by_data(self):
         calendar = Calendar()

--- a/tests/test_cdav.py
+++ b/tests/test_cdav.py
@@ -16,7 +16,7 @@ SOMEWHERE_REMOTE = zoneinfo.ZoneInfo("Brazil/DeNoronha")  # UTC-2 and no DST
 def test_element():
     cq = CalendarQuery()
     assert str(cq).startswith("<?xml")
-    assert not "xml" in repr(cq)
+    assert "xml" not in repr(cq)
     assert "CalendarQuery" in repr(cq)
     assert "calendar-query" in str(cq)
 
@@ -29,11 +29,7 @@ def test_to_utc_date_string_date():
 
 def test_to_utc_date_string_utc():
     input = datetime.datetime(2019, 5, 14, 21, 10, 23, 23, tzinfo=datetime.timezone.utc)
-    try:
-        res = _to_utc_date_string(input.astimezone())
-    except:
-        ## old python does not support astimezone() without a parameter given
-        res = _to_utc_date_string(input.astimezone(tzlocal.get_localzone()))
+    res = _to_utc_date_string(input.astimezone())
     assert res == "20190514T211023Z"
 
 
@@ -45,10 +41,7 @@ def test_to_utc_date_string_dt_with_zoneinfo_tzinfo():
 
 def test_to_utc_date_string_dt_with_local_tz():
     input = datetime.datetime(2019, 5, 14, 21, 10, 23, 23)
-    try:
-        res = _to_utc_date_string(input.astimezone())
-    except:
-        res = _to_utc_date_string(tzlocal.get_localzone())
+    res = _to_utc_date_string(input.astimezone())
     exp_dt = datetime.datetime(
         2019, 5, 14, 21, 10, 23, 23, tzinfo=tzlocal.get_localzone()
     ).astimezone(datetime.timezone.utc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,9 +8,9 @@ class TestUtils(TestCase):
         # fmt: off
         self.assertEqual(to_wire('blatti'), b'blatti')
         self.assertEqual(to_wire(b'blatti'), b'blatti')
-        self.assertEqual(to_wire(u'blatti'), b'blatti')
+        self.assertEqual(to_wire('blatti'), b'blatti')
         self.assertEqual(to_wire(''), b'')
-        self.assertEqual(to_wire(u''), b'')
+        self.assertEqual(to_wire(''), b'')
         self.assertEqual(to_wire(b''), b'')
         self.assertEqual(to_wire(None), None)
         # fmt: on

--- a/tests/test_vcal.py
+++ b/tests/test_vcal.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import re
-import uuid
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -14,7 +13,6 @@ from caldav.lib import vcal
 from caldav.lib.python_utilities import to_normal_str
 from caldav.lib.python_utilities import to_wire
 from caldav.lib.vcal import create_ical
-from caldav.lib.vcal import fix
 
 utc = timezone.utc
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox:tox]
-envlist = py37,py38,py39,py310,py311,py312,docs,style
-
+envlist = py38,py39,py310,py311,py312,docs,style
+requires =
+    tox>=4
 [testenv]
-deps = --editable .[test]
-commands = coverage run -m pytest
-
+usedevelop = true
+extras = test
+deps = radicale
+commands =
+    coverage: coverage run -m pytest []
+    !coverage: pytest []
 [testenv:docs]
 deps = sphinx
 commands =


### PR DESCRIPTION
this starts with the isort and pyugprade rules + flake8 based rules
some warnings are resolved - about 141 more to go 

i stumbled across a number of leftovers from historic python2 support

i'd like to get some input on whether adding type annotations would be appreciated or frowned upon
i'd like to get input on whether this type of project modernization would be appreciated or not before digging into the leftover linter warnings