### PR TITLE
Change fixup log lvl to warning and merge diff log messages into related parent log

### DIFF
--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -89,8 +89,8 @@ def fix(event):
     if fixed2 != event:
         global fixup_error_loggings
         fixup_error_loggings += 1
-        is_multiple_of_two = lambda n: not (n & (n - 1))
-        if is_multiple_of_two(fixup_error_loggings):
+        is_power_of_two = lambda n: not (n & (n - 1))
+        if is_power_of_two(fixup_error_loggings):
             log = logging.warning
         else:
             log = logging.debug

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -91,7 +91,7 @@ def fix(event):
         fixup_error_loggings += 1
         is_multiple_of_two = lambda n: not (n & (n - 1))
         if is_multiple_of_two(fixup_error_loggings):
-            log = logging.error
+            log = logging.warning
         else:
             log = logging.debug
 

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -89,32 +89,29 @@ def fix(event):
     if fixed2 != event:
         global fixup_error_loggings
         fixup_error_loggings += 1
-        remove_bit = lambda n: n & (n - 1)
-        if not remove_bit(fixup_error_loggings):
+        is_multiple_of_two = lambda n: not (n & (n - 1))
+        if is_multiple_of_two(fixup_error_loggings):
             log = logging.error
         else:
             log = logging.debug
-        log(
-            """Ical data was modified to avoid compatibility issues
-(Your calendar server breaks the icalendar standard)
-This is probably harmless, particularly if not editing events or tasks
-(error count: %i - this error is ratelimited)"""
-            % fixup_error_loggings,
-            exc_info=True,
-        )
+
+        log_message = [
+            "Ical data was modified to avoid compatibility issues",
+            "(Your calendar server breaks the icalendar standard)",
+            "This is probably harmless, particularly if not editing events or tasks",
+            f"(error count: {fixup_error_loggings} - this error is ratelimited)",
+        ]
+
         try:
             import difflib
 
-            log(
-                "\n".join(
-                    difflib.unified_diff(
-                        event.split("\n"), fixed2.split("\n"), lineterm=""
-                    )
-                )
+            diff = list(
+                difflib.unified_diff(event.split("\n"), fixed2.split("\n"), lineterm="")
             )
         except:
-            log("Original: \n" + event)
-            log("Modified: \n" + fixed2)
+            diff = ["Original: ", event, "Modified: ", fixed2]
+
+        log("\n".join(log_message + diff))
 
     return fixed2
 


### PR DESCRIPTION
This PR merges the two fix up log messages into one. The diff log can be confusing when the log is viewed outside the console. (see image from Home Assistants log view)

![image](https://github.com/user-attachments/assets/8961a801-5584-48a1-8a36-25810d26fb77)

~~I haven't touched the log level yet.~~

See: https://github.com/python-caldav/caldav/issues/426#issuecomment-2395409450


