### PR TITLE
Documentation: get the sync to the readthedocs website working again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project should more or less adhere to [Semantic Versioning](https://semver.
 
 ## [Unreleased]
 
+## TODO - is this relevant?
+* Tests - a breakage was introduced for servers not supporting MKCALENDAR - details in https://github.com/python-caldav/caldav/pull/368
+* Tests - all tests passes for python 3.12 as well - as expected.  Fixed a minor bug in the ftests and tweaked the compatibility matrixes a bit.  Commits outside pull requests + https://github.com/python-caldav/caldav/pull/370
+
 ### Changed
 
 #### Test framework

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,8 @@ Project home
 The project currently lives on github,
 https://github.com/python-caldav/caldav - if you have problems using
 the library (including problems understanding the documentation),
-please feel free to report it on the issue tracker there.
+please feel free to report it on the issue tracker there or to
+python-caldav@tobixen.no
 
 Backward compatibility support
 ==============================


### PR DESCRIPTION
It's needed to argue a bit with readthedocs to get those pages working again.  I looked into it a long time ago, but didn't succeed.  (I also messed up a bit with the branches).