### PR TITLE
Fixing _set_icalendar_component: language not defined

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -2187,8 +2187,8 @@ class CalendarObjectResource(DAVObject):
             self.icalendar_instance.subcomponents[i[0]] = value
         else:
             my_instance = icalendar.Calendar()
-            my_instance.add("prodid", "-//python-caldav//caldav//" + language)
-            my_instance.add("version", "2.0")
+            my_instance.add("prodid", self.icalendar_instance["prodid"])
+            my_instance.add("version", self.icalendar_instance["version"])
             my_instance.add_component(value)
             self.icalendar_instance = my_instance
 

--- a/tests/test_caldav_unit.py
+++ b/tests/test_caldav_unit.py
@@ -1098,6 +1098,19 @@ END:VCALENDAR
             == "Submit Quebec Income Tax Return for 2006"
         )
 
+    def testComponentSet(self):
+        cal_url = "http://me:hunter2@calendar.example:80/"
+        client = DAVClient(url=cal_url)
+        target = Event(client, data=evr)
+
+        ## Creating some dummy data such that the target has more than one subcomponent
+        target.expand_rrule(start=datetime(1996, 10, 10), end=datetime(1999, 12, 12))
+        assert len(target.icalendar_instance.subcomponents) == 3
+
+        ## The following should not fail within _set_icalendar_component
+        target.icalendar_component = icalendar.Todo.from_ical(todo).subcomponents[0]
+        assert len(target.icalendar_instance.subcomponents) == 1
+
     def testTodoDuration(self):
         cal_url = "http://me:hunter2@calendar.example:80/"
         client = DAVClient(url=cal_url)


### PR DESCRIPTION
`CalendarObjectResource`'s `_set_icalendar_component`, if the target had more than one subcomponent, would always fail because the variable `language` was not defined. I reckon this was a copy & paste bug. Contributing a simple fix with unit test.