### PR TITLE
Servers that return a quoted URL in their path will now be parsed correctly

### DIFF
--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -312,6 +312,7 @@ class DAVObject:
             exchange_path = path[:-1]
         else:
             exchange_path = path + "/"
+        properties = {unquote(k): v for k, v in properties.items()}
 
         if path in properties:
             rc = properties[path]


### PR DESCRIPTION
Fixes #471 
`pytest` looks the same before and after modifications
`tox -e style` has been run: no changes made