### PR TITLE
Revert #472 and re-address #471

### DIFF
--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -220,6 +220,10 @@ class DAVResponse:
                 self.validate_status(status)
             elif elem.tag == dav.Href.tag:
                 assert not href
+                # Fix for https://github.com/python-caldav/caldav/issues/471
+                # Confluence server quotes the user email twice. We unquote it manually.
+                if '%2540' in elem.text:
+                    elem.text = elem.text.replace('%2540', '%40')
                 href = unquote(elem.text)
             elif elem.tag == dav.PropStat.tag:
                 propstats.append(elem)

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -222,8 +222,8 @@ class DAVResponse:
                 assert not href
                 # Fix for https://github.com/python-caldav/caldav/issues/471
                 # Confluence server quotes the user email twice. We unquote it manually.
-                if '%2540' in elem.text:
-                    elem.text = elem.text.replace('%2540', '%40')
+                if "%2540" in elem.text:
+                    elem.text = elem.text.replace("%2540", "%40")
                 href = unquote(elem.text)
             elif elem.tag == dav.PropStat.tag:
                 propstats.append(elem)

--- a/caldav/objects.py
+++ b/caldav/objects.py
@@ -312,7 +312,6 @@ class DAVObject:
             exchange_path = path[:-1]
         else:
             exchange_path = path + "/"
-        properties = {unquote(k): v for k, v in properties.items()}
 
         if path in properties:
             rc = properties[path]


### PR DESCRIPTION
Related to #471 and #472 
After having a deeper look at it, it seems that unquoting all properties could make other servers break.
I propose that we only apply a fix when the situation requires it only.
This will reduce error logging and hopefully won't break other servers.


This is the request and reply this PR addresses:

URL: `https://confluence.domain.com/plugins/servlet/team-calendars/caldav/principals/users/user@domain.com/`
Method: PROPFIND

RESPONSE:
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<DAV:multistatus xmlns:DAV="DAV:" xmlns="urn:ietf:params:xml:ns:caldav" xmlns:AI="http://apple.com/ns/ical/" xmlns:BSS="http://bedeworkcalserver.org/ns/" xmlns:CS="http://calendarserver.org/ns/" xmlns:ical="http://www.w3.org/2002/12/cal/ical#">
      
    <DAV:response>
            
        <DAV:href>/plugins/servlet/team-calendars/caldav/principals/users/user%2540domain.com/</DAV:href>
            
        <DAV:propstat>
                  
            <DAV:prop>
                    
                <calendar-home-set>
                              
                    <DAV:href>/plugins/servlet/team-calendars/caldav/calendars</DAV:href>
                            
                </calendar-home-set>
                      
            </DAV:prop>
                  
            <DAV:status>HTTP/1.1 200 ok</DAV:status>
                
        </DAV:propstat>
          
    </DAV:response>
    
</DAV:multistatus>
```