### PR TITLE
Move start/end/duration logic to the icalendar library

### DIFF
--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -543,6 +543,10 @@ class CalendarObjectResource(DAVObject):
         self.load(only_if_unloaded=True)
         return self.icalendar_instance.get("method", None) == "REQUEST"
 
+    def is_invite_reply(self) -> bool:
+        self.load(only_if_unloaded=True)
+        return self.icalendar_instance.get("method", None) == "REPLY"
+
     def accept_invite(self, calendar: Optional["Calendar"] = None) -> None:
         self._reply_to_invite_request("ACCEPTED", calendar)
 
@@ -729,7 +733,7 @@ class CalendarObjectResource(DAVObject):
             if self.client is None:
                 raise ValueError("Unexpected value None for self.client")
 
-            attendee = self.client.principal_address or self.client.principal()
+            attendee = self.client.principal()
 
         cnt = 0
 

--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -456,19 +456,10 @@ class CalendarObjectResource(DAVObject):
         """
         A VTODO may have due or duration set.  Return or calculate due.
 
-        WARNING: this method is likely to be deprecated and moved to
-        the icalendar library.  If you decide to use it, please put
-        caldav<2.0 in the requirements.
+        DEPRECATION WARNING: this method is likely to be removed in
+        caldav v3.0.  Use self.icalendar.end instead.
         """
-        i = self.icalendar_component
-        if "DUE" in i:
-            return i["DUE"].dt
-        elif "DTEND" in i:
-            return i["DTEND"].dt
-        elif "DURATION" in i and "DTSTART" in i:
-            return i["DTSTART"].dt + i["DURATION"].dt
-        else:
-            return None
+        return self.icalendar_component.end
 
     get_dtend = get_due
 
@@ -976,7 +967,10 @@ class CalendarObjectResource(DAVObject):
     )
 
     def get_duration(self) -> timedelta:
-        """According to the RFC, either DURATION or DUE should be set
+        """
+        DEPRECATION WARNING: This method may be removed in version 3.0
+
+        According to the RFC, either DURATION or DUE should be set
         for a task, but never both - implicitly meaning that DURATION
         is the difference between DTSTART and DUE (personally I
         believe that's stupid.  If a task takes five minutes to
@@ -997,29 +991,11 @@ class CalendarObjectResource(DAVObject):
         the icalendar library.  If you decide to use it, please put
         caldav<3.0 in the requirements.
         """
-        i = self.icalendar_component
-        return self._get_duration(i)
+        return self.icalendar_component.duration
 
-    def _get_duration(self, i):
-        if "DURATION" in i:
-            return i["DURATION"].dt
-        elif "DTSTART" in i and self._ENDPARAM in i:
-            end = i[self._ENDPARAM].dt
-            start = i["DTSTART"].dt
-            ## We do have a problem here if one is a date and the other is a
-            ## datetime.  This is NOT explicitly defined as a technical
-            ## breach in the RFC, so we need to work around it.
-            if isinstance(end, datetime) != isinstance(start, datetime):
-                start = datetime(start.year, start.month, start.day)
-                end = datetime(end.year, end.month, end.day)
-            return end - start
-        elif "DTSTART" in i and not isinstance(i["DTSTART"], datetime):
-            return timedelta(days=1)
-        else:
-            return timedelta(0)
-
+    ## DEPRECATION WARNING:
     ## for backward-compatibility - may be changed to
-    ## icalendar_instance in version 1.0
+    ## icalendar_instance in version 3.0
     instance: VBase = vobject_instance
 
 
@@ -1168,7 +1144,7 @@ class Todo(CalendarObjectResource):
                 else:
                     dtstart = ts or datetime.now()
             else:
-                dtstart = ts or datetime.now() - self._get_duration(i)
+                dtstart = ts or datetime.now() - i.duration
         ## dtstart should be compared to the completion timestamp, which
         ## is set in UTC in the complete() method.  However, dtstart
         ## may be a naïve or a floating timestamp
@@ -1303,7 +1279,7 @@ class Todo(CalendarObjectResource):
 
         rrule = rrule2 or rrule
 
-        duration = self._get_duration(i=prev)
+        duration = prev.duration
         thisandfuture.pop("DTSTART", None)
         thisandfuture.pop("DUE", None)
         next_dtstart = self._next(i=prev, rrule=rrule, ts=completion_timestamp)

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -490,7 +490,7 @@ class TestScheduling:
             except error.NotFoundError:
                 pass
         for c in self.clients:
-            c.teardown()
+            c.teardown(c)
 
     ## TODO
     # def testFreeBusy(self):


### PR DESCRIPTION
Work on issue #482 - remove logic on `get_due`, `get_duration` etc, it belongs to the icalendar library.  Also references https://github.com/collective/icalendar/issues/496