### PR TITLE
Fix a bug in loading davobject

### DIFF
--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -634,8 +634,7 @@ class CalendarObjectResource(DAVObject):
         except error.NotFoundError:
             raise
         except:
-            self.load_by_multiget()
-        self.data = vcal.fix(r.raw)
+            return self.load_by_multiget()
         if "Etag" in r.headers:
             self.props[dav.GetEtag.tag] = r.headers["Etag"]
         if "Schedule-Tag" in r.headers:

--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -631,6 +631,7 @@ class CalendarObjectResource(DAVObject):
             r = self.client.request(str(self.url))
             if r.status and r.status == 404:
                 raise error.NotFoundError(errmsg(r))
+            self.data = r.raw
         except error.NotFoundError:
             raise
         except:


### PR DESCRIPTION
To solve the issue #505 

1. Removed `vcal.fix` as it has been implemented in _set_data
2. Return `load_by_multiget()` when GET fails.


