### PR TITLE
Use PEP 639 license expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Links:
 
 Licences:
 
-Caldav is dual-licensed under the [GNU GENERAL PUBLIC LICENSE Version 3](COPYING.GPL) and the [Apache License 2.0](COPYING.APACHE).
+Caldav is dual-licensed under the [GNU GENERAL PUBLIC LICENSE Version 3](COPYING.GPL) or the [Apache License 2.0](COPYING.APACHE).

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -285,4 +285,4 @@ While I hope we never will need to refer to it, the `Contributor Covenant <https
 License
 =======
 
-Caldav is dual-licensed under the GNU GENERAL PUBLIC LICENSE Version 3 and the Apache License 2.0.
+Caldav is dual-licensed under the GNU GENERAL PUBLIC LICENSE Version 3 or the Apache License 2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -11,15 +11,14 @@ version-file = "caldav/_version.py"
 [project]
 name = "caldav"
 authors = [{ name = "Cyril Robert", email = "cyril@hippie.io" }, { name = "Tobias Brox", email = "caldav@plann.no" }]
-license = { text = "GPL" }
+license = "GPL-3.0-or-later OR Apache-2.0"
+license-files = ["COPYING.*"]
 description = "CalDAV (RFC4791) client library"
 keywords = []
 readme = "README.md"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: GNU General Public License (GPL)",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Hatchling `1.27.0` added support for PEP 639 license expression. I believe it can be helpful to clarify the licensing situation.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

Ref: #60

Metadata diff
```diff
 ...
-License: GPL
+License-Expression: GPL-3.0-or-later OR Apache-2.0
 License-File: COPYING.APACHE
 License-File: COPYING.GPL
 ...
-Classifier: License :: OSI Approved :: Apache Software License
-Classifier: License :: OSI Approved :: GNU General Public License (GPL)
 ...
```