### PR TITLE
Bugfix - search could give objects of wrong classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ This project should adhere to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased]
 
-The niquests dependency has proven controversial.  See https://github.com/python-caldav/caldav/issues/457 https://github.com/python-caldav/caldav/issues/530 https://github.com/jawah/niquests/issues/267 for details.  While continuing work on the 2.x-series I've decided to always release two versions of caldav, one based on requests and the next one based on niquests - giving package maintainers and other parties the option to choose between niquests (which resolves some of the issues reported to the caldav library) and requests (which is mature and firmly established in the python community, although fading to irrelevance unless 3.0 is shipped soon).  Master branch will use niquests, as it's more forward-leaning.  I will make a new decision on this before starting work on 3.0.
+### Fixes
+
+* A search without filtering on comp-type on a calendar containing a mix of events, journals and tasks should return a mix of such.  (All the examples in the RFC includes the comp-type filter, so many servers does not support this).  There were a bug in the auto-detection of comp-type, so tasks would typically be wrapped as events or vice-versa.  https://github.com/python-caldav/caldav/pull/540
+
+### Other
+
+* Example code: Basic usage examples have been brushed up, thanks to David Greaves - https://github.com/python-caldav/caldav/pull/534
+* PEP 639 conforming license expression in the pyproject.toml, thanks to Marc Mueller - https://github.com/python-caldav/caldav/pull/538
 
 ## [2.0.1] - [2025-06-24]
 

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -730,13 +730,12 @@ class Calendar(DAVObject):
             pdata = results[r]
             if cdav.CalendarData.tag in pdata:
                 cdata = pdata.pop(cdav.CalendarData.tag)
-                if comp_class is None:
-                    comp_class = self._calendar_comp_class_by_data(cdata)
+                comp_class_ = self._calendar_comp_class_by_data(cdata) if comp_class is None else comp_class
             else:
                 cdata = None
-            if comp_class is None:
+            if comp_class_ is None:
                 ## no CalendarData fetched - which is normal i.e. when doing a sync-token report and only asking for the URLs
-                comp_class = CalendarObjectResource
+                comp_class_ = CalendarObjectResource
             url = URL(r)
             if url.hostname is None:
                 # Quote when result is not a full URL
@@ -745,7 +744,7 @@ class Calendar(DAVObject):
             if self.url.join(url) == self.url:
                 continue
             matches.append(
-                comp_class(
+                comp_class_(
                     self.client,
                     url=self.url.join(url),
                     data=cdata,

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -730,7 +730,11 @@ class Calendar(DAVObject):
             pdata = results[r]
             if cdav.CalendarData.tag in pdata:
                 cdata = pdata.pop(cdav.CalendarData.tag)
-                comp_class_ = self._calendar_comp_class_by_data(cdata) if comp_class is None else comp_class
+                comp_class_ = (
+                    self._calendar_comp_class_by_data(cdata)
+                    if comp_class is None
+                    else comp_class
+                )
             else:
                 cdata = None
             if comp_class_ is None:

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -2490,7 +2490,7 @@ END:VCALENDAR
         cal.save_event(ev1)
         objects = cal.search()
         assert len(objects) == 2
-        assert set([str(type(x)) for x in objects]) == {"Todo", "Event"}
+        assert set([type(x).__name__ for x in objects]) == {"Todo", "Event"}
 
     def testTodoCompletion(self):
         """

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -2477,6 +2477,21 @@ END:VCALENDAR
         # TODO: prod the caldav server implementers about the RFC
         # breakages.
 
+    def testSearchWithoutCompType(self):
+        """
+        Test for https://github.com/python-caldav/caldav/issues/539
+        """
+        self.skip_on_compatibility_flag("search_needs_comptype")
+        self.skip_on_compatibility_flag("search_always_needs_comptype")
+        self.skip_on_compatibility_flag("no_todo")
+        self.skip_on_compatibility_flag("no_events_and_tasks_on_same_calendar")
+        cal = self._fixCalendar()
+        cal.save_todo(todo)
+        cal.save_event(ev1)
+        objects = cal.search()
+        assert len(objects) == 2
+        assert set([str(type(x)) for x in objects]) == {"Todo", "Event"}
+
     def testTodoCompletion(self):
         """
         Will check that todo-items can be completed and deleted


### PR DESCRIPTION
A search without filtering on comp-type on a calendar containing a mix of events, journals and tasks should return a mix of such.  (All the examples in the RFC includes the comp-type filter, so many servers does not support this).  There were a bug in the auto-detection of comp-type, so tasks would typically be wrapped as events or vice-versa.

Also ensured the CHANGELOG.md contains all changes since 2.0.0 was released.

Fixes https://github.com/python-caldav/caldav/issues/539