### PR TITLE
accept icalendar event/todo objects and not only calendar

### DIFF
--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -1009,8 +1009,8 @@ class CalendarObjectResource(DAVObject):
         potentially breaking couplings
         """
         return (
-            self._data or self._vobject_instance or self._icalendar_instance
-        ) and self.data.count("BEGIN:") > 1
+            (self._data and self._data.count("BEGIN:") > 1) or self._vobject_instance or self._icalendar_instance
+        )
 
     def has_component(self):
         """
@@ -1145,6 +1145,18 @@ class CalendarObjectResource(DAVObject):
     )
 
     def _set_icalendar_instance(self, inst):
+        if not isinstance(inst, icalendar.Calendar):
+            ## assume inst is an Event, Journal or Todo.
+            ## TODO: perhaps a bit better sanity checking here?
+            try: ## DEPRECATION TODO: remove this try/except the future
+                ## icalendar 7.x behaviour (not released yet as of 2025-09
+                cal = icalendar.Calendar.new()
+            except:
+                cal = icalendar.Calendar()
+                cal.add("prodid", "-//python-caldav//caldav//en_DK")
+                cal.add("version", "2.0")
+            cal.add_component(inst)
+            inst = cal
         self._icalendar_instance = inst
         self._data = None
         self._vobject_instance = None

--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -1009,7 +1009,9 @@ class CalendarObjectResource(DAVObject):
         potentially breaking couplings
         """
         return (
-            (self._data and self._data.count("BEGIN:") > 1) or self._vobject_instance or self._icalendar_instance
+            (self._data and self._data.count("BEGIN:") > 1)
+            or self._vobject_instance
+            or self._icalendar_instance
         )
 
     def has_component(self):
@@ -1148,7 +1150,7 @@ class CalendarObjectResource(DAVObject):
         if not isinstance(inst, icalendar.Calendar):
             ## assume inst is an Event, Journal or Todo.
             ## TODO: perhaps a bit better sanity checking here?
-            try: ## DEPRECATION TODO: remove this try/except the future
+            try:  ## DEPRECATION TODO: remove this try/except the future
                 ## icalendar 7.x behaviour (not released yet as of 2025-09
                 cal = icalendar.Calendar.new()
             except:

--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -282,7 +282,7 @@ class FeatureSet:
 
         (this is very simple now - used to be a hierarchy dict to be traversed)
         """
-        assert feature in cls.FEATURES ## TODO ... raise a better exception?
+        assert feature in cls.FEATURES ## A feature in the configured feature-list does not exist.  TODO ... raise a better exception?
         if not 'name' in cls.FEATURES[feature]:
             cls.FEATURES[feature]['name'] = feature
         if '.' in feature and not 'parent' in cls.FEATURES[feature]:
@@ -715,18 +715,23 @@ baikal = [
 #    'object_by_uid_is_broken'
 #]
 
-davical = [
-    #'no_journal', ## it threw a 500 internal server error! ## for old versions
-    #'nofreebusy', ## for old versions
-    'fragile_sync_tokens', ## no issue raised yet
-    'vtodo_datesearch_nodtstart_task_is_skipped', ## no issue raised yet
-    'broken_expand_on_exceptions', ## no issue raised yet
-    'date_todo_search_ignores_duration',
-    'calendar_color',
-    'calendar_order',
-    'vtodo_datesearch_notime_task_is_skipped',
-    "no_alarmsearch",
-]
+davical = {
+    "search.category.fullstring.smart": { "support": "unsupported" },
+    "search.comp-type-optional": { "support": "fragile" },
+    "search.recurrences.expanded.todo": { "support": "unsupported" },
+    "search.recurrences.expanded.exception": { "support": "unsupported" },
+    "old_flags": [
+        #'no_journal', ## it threw a 500 internal server error! ## for old versions
+        #'nofreebusy', ## for old versions
+        'fragile_sync_tokens', ## no issue raised yet
+        'vtodo_datesearch_nodtstart_task_is_skipped', ## no issue raised yet
+        'date_todo_search_ignores_duration',
+        'calendar_color',
+        'calendar_order',
+        'vtodo_datesearch_notime_task_is_skipped',
+        "no_alarmsearch",
+    ]
+}
 
 #google = [
 #    'no_mkcalendar',
@@ -783,21 +788,29 @@ nextcloud = [
 #    "no_recurring_todo",
 #]
 
-robur = [
-    'non_existing_raises_other', ## AuthorizationError instead of NotFoundError
-    'no_scheduling',
-    'no_sync_token',
-    'no_supported_components_support',
-    'no_journal',
-    'no_freebusy_rfc4791',
-    'no_todo_datesearch', ## returns nothing
-    'text_search_not_working',
-    "no-principal-search",
-    'no_relships',
-    'isnotdefined_not_working',
-    'no_alarmsearch',
-    'broken_expand',
-]
+robur = {
+    "delete-calendar": {  "support": "fragile" },
+    "search.time-range.todo": { "support": "unsupported" },
+    "search.category": { "support": "unsupported" },
+    "search.comp-type-optional": { "support": "ungraceful" },
+    "search.recurrences.expanded.todo": { "support": "unsupported" },
+    "search.recurrences.expanded.exception": { "support": "unsupported" },
+    'old_flags': [
+        'non_existing_raises_other', ## AuthorizationError instead of NotFoundError
+        'no_scheduling',
+        'no_sync_token',
+        'no_supported_components_support',
+        'no_journal',
+        'no_freebusy_rfc4791',
+        'no_todo_datesearch', ## returns nothing
+        'text_search_not_working',
+        "no-principal-search",
+        'no_relships',
+        'isnotdefined_not_working',
+        'no_alarmsearch',
+        'broken_expand'
+    ]
+}
 
 posteo = [
     'no_scheduling',

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -165,7 +165,10 @@ def create_ical(ical_fragment=None, objtype=None, language="en_DK", **props):
         my_instance = icalendar.Calendar()
         if objtype is None:
             objtype = "VEVENT"
-        component = icalendar.cal.component_factory[objtype]()
+        try:
+            component = icalendar.cal.component_factory[objtype]()
+        except:
+            component = icalendar.cal.component_factory.ComponentFactory()[objtype]()
         my_instance.add_component(component)
         ## STATUS should default to NEEDS-ACTION for tasks, if it's not set
         ## (otherwise we cannot easily add a task to a davical calendar and

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1167,6 +1167,24 @@ END:VCALENDAR
         assert len(events) == len(existing_events) + 2
         ev2.delete()
 
+    @pytest.mark.parametrize("klass", ["Calendar", "Event"])
+    def testCreateEventFromiCal(self, klass):
+        c = self._fixCalendar()
+        icalcal = icalendar.Calendar.new()
+        icalevent = icalendar.Event.new(
+            uid="ctuid1",
+            start=datetime(2015, 10, 10, 8, 7, 6),
+            end=datetime(2015, 10, 10, 9, 7, 6),
+            summary="This is a test event",
+        )
+        icalcal.add_component(icalevent)
+        
+        ## Parametrized test - we should test both with the Calendar object and the Event object
+        obj = { "Calendar": icalcal, "Event": icalevent }[klass]
+        event = c.save_event(obj)
+        events = c.events()
+        assert len([x for x in events if x.icalendar_component['uid'] == 'ctuid1']) == 1
+        
     def testAlarm(self):
         ## Ref https://github.com/python-caldav/caldav/issues/132
         c = self._fixCalendar()

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1210,7 +1210,7 @@ END:VCALENDAR
     @pytest.mark.parametrize("klass", ["Calendar", "Event"])
     def testCreateEventFromiCal(self, klass):
         c = self._fixCalendar()
-        try: ## TODO: remove this try-except
+        try:  ## TODO: remove this try-except
             icalcal = icalendar.Calendar.new()
         except:
             ## Calendar.new() is supported from icalendar 7, which is yet to be released as of 2025-09
@@ -1223,13 +1223,13 @@ END:VCALENDAR
             summary="This is a test event",
         )
         icalcal.add_component(icalevent)
-        
+
         ## Parametrized test - we should test both with the Calendar object and the Event object
-        obj = { "Calendar": icalcal, "Event": icalevent }[klass]
+        obj = {"Calendar": icalcal, "Event": icalevent}[klass]
         event = c.save_event(obj)
         events = c.events()
-        assert len([x for x in events if x.icalendar_component['uid'] == 'ctuid1']) == 1
-        
+        assert len([x for x in events if x.icalendar_component["uid"] == "ctuid1"]) == 1
+
     def testAlarm(self):
         ## Ref https://github.com/python-caldav/caldav/issues/132
         c = self._fixCalendar()


### PR DESCRIPTION
Users of the library are trying to push icalendar Event objects into the caldav library, and it fails.  The CalDAV protocol demands that each "calendar object resource" is wrapped in an icalendar Calendar, but one of the objectives with this library is that users should not need to know many details about the CalDAV protocol.  Hence this should be possible.

Solves #546 

Partial fix for #541

Caveat: the fix has two code paths, one for the (yet to be published) icalendar>=7 and another for icalendar<7.  However, the test code will only run on icalendar>=7 - meaning that this fix has not been verified for icalendar 6.