### PR TITLE
More compatibility work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## IMPORTANT - niquests vs requests - flapping changeset
 
-The requests library is stagnant, from 2.0.0 niquests has been in use.  It's a very tiny changeset, which resolved three github issues, fixed support for HTTP/2 and may open the door for an upcoming async proejct.  While I haven't looked much "under the bonnet", niquests seems to be a major upgrade of requests.  However, the niquest author has apparently failed cooperating well with some significant parts of the python community, so niquests pulls in a lot of other forked libraries as for now.  Shortly after releasing 2.0 I was requested to revert back to requests and release 2.0.1.  After 2.0.1, the library has been fixed so that it will always use niquests if niquests is available, and requests if niquests is not available.
+The requests library is stagnant, from 2.0.0 niquests has been in use.  It's a very tiny changeset, which resolved three github issues (and created a new one - see https://github.com/python-caldav/caldav/issues/564), fixed support for HTTP/2 and may open the door for an upcoming async proejct.  While I haven't looked much "under the bonnet", niquests seems to be a major upgrade of requests.  However, the niquest author has apparently failed cooperating well with some significant parts of the python community, so niquests pulls in a lot of other forked libraries as for now.  Shortly after releasing 2.0 I was requested to revert back to requests and release 2.0.1.  After 2.0.1, the library has been fixed so that it will always use niquests if niquests is available, and requests if niquests is not available.
 
-You are encouraged to make an informed decision on weather you are most comfortable with the stable but stagnant requests, or the niquests fork.  I hope to settle down on some final decision when I'm starting to work on 3.0 (which will support async requests).  httpx may be an option.  **Your opinion is valuable for me**.  Feel free to comment on https://github.com/python-caldav/caldav/issues/457,  https://github.com/python-caldav/caldav/issues/530 or https://github.com/jawah/niquests/issues/267 if you have a github account, and if not you can reach out at python-http@plann.no.  (So far the most common recommendation seems to be to go for httpx.
+You are encouraged to make an informed decision on weather you are most comfortable with the stable but stagnant requests, or the niquests fork.  I hope to settle down on some final decision when I'm starting to work on 3.0 (which will support async requests).  httpx may be an option.  **Your opinion is valuable for me**.  Feel free to comment on https://github.com/python-caldav/caldav/issues/457,  https://github.com/python-caldav/caldav/issues/530 or https://github.com/jawah/niquests/issues/267 - if you have a github account, and if not you can reach out at python-http@plann.no.
+
+So far the most common recommendation seems to be to go for httpx.  See also https://github.com/python-caldav/caldav/pull/565
 
 ## Meta
 
@@ -22,27 +24,35 @@ I'm still working on "compatibility hints".  Unfortunately, documentation is sti
 * Use `features: nextcloud` and `url: my.nextcloud.provider.eu` instead of `url: https://my.nextcloud.provider.eu/remote.php/dav`
 * The library will work around some known issues dependent on what feature-set it's given.
 
-Searching may now be done by creating a `caldav.CalDAVSearcher` object and do a `searcher.search(cal)` instead of doing `cal.search(...)`.  However, there are no plans to deprecate the latter method.  Major refactoring work has been done here, and some of the logic has been moved to a new package icalendar-searcher.
+Searching may now be done by creating a `caldav.CalDAVSearcher` object and do a `searcher.search(cal)` instead of doing `cal.search(...)`.  While there are no plans to deprecate the latter method, the new logic offers more features.  Major refactoring work has been done here, and some of the logic has been moved to a new package icalendar-searcher.
 
-## Breaking Changes
+### Breaking Changes
 
-Some code has been split out into a new package - `icalendar-searcher`.  This does not affect compatibility, hence it's not needed to bump the major version number, but if you manage the dependencies manually it may still cause things to break.
+* Some code has been split out into a new package - `icalendar-searcher`.  This does not affect compatibility, hence it's not needed to bump the major version number, but if you manage the dependencies manually it may still cause things to break.
+* Lots of work has been put in to work around server-quirks, ensuring more consistent search-results regardless of what server is in use.  For some use cases this may be a breaking change as search results from certain servers may have changed (see more below).
 
-## Deprecations
+### Deprecations
 
 * `Event.expand_rrule` will be removed in some future release, unless someone protests.
 * `Event.split_expanded` too.  Both of them were used internally, now it's not.  It's dead code, most lkely nobody and nothing is using them.
 
-## Changed
+### Changed
 
 * Major refactoring!  Some of the logic has been pushed out of the CalDAV package and into a new package, icalendar-searcher.  New logic for doing client-side filtering of search results have also been added to that package.
+* **Server compatibility improvements**: Significant work-arounds added for inconsistent CalDAV server behavior, aiming for consistent search results regardless of the server in use. Many of these work-arounds require proper server compatibility configuration via the `features` / `compatibility_hints` system. This may be a **breaking change** for some use cases, as backward-bug-compatibility is not preserved - searches may return different results if the previous behavior was relying on server quirks.
 
-## Added
+### Added
 
 * The client connection parameter `features` may now simply be a string label referencing a well-known server or cloud solution - like `features: posteo`.  https://github.com/python-caldav/caldav/pull/561
 * The client connection parameter `url` is no longer needed when referencing a well-known cloud solution. https://github.com/python-caldav/caldav/pull/561
 * The client connection parameter `url` may contain just the domain name (without any slashes) and the URL will be constructed, if referencing a well-known caldav server implementation. https://github.com/python-caldav/caldav/pull/561
 * New interface for searches.  `mysearcher = caldav.CalDAVSearcher(...) ; mysearcher.add_property_filter(...) ; mysearcher.search(calendar)`.  May be useful for complicated searches.
+* **Collation support for CalDAV text-match queries (RFC 4791 § 9.7.5)**: CalDAV searches now properly pass collation attributes to the server, enabling case-insensitive searches and Unicode-aware text matching. The `CalDAVSearcher.add_property_filter()` method now accepts `case_sensitive` and `collation` parameters. Supported collations include:
+  - `i;octet` (case-sensitive, binary comparison) - default
+  - `i;ascii-casemap` (case-insensitive for ASCII characters, RFC 4790)
+  - `i;unicode-casemap` (Unicode case-insensitive, RFC 5051 - server support may vary)
+* Client-side filtering method: `CalDAVSearcher.filter()` provides comprehensive client-side filtering, expansion, and sorting of calendar objects with full timezone preservation support.
+* Example code: New `examples/collation_usage.py` demonstrates case-sensitive and case-insensitive calendar searches.
 
 ## [2.1.2] - [2025-11-08]
 

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -913,8 +913,6 @@ class Calendar(DAVObject):
             alias = key
             if key == "class_":  ## because class is a reserved word
                 alias = "class"
-            if key == "category":  ## TODO: should we have special logic?
-                alias = "categories"
             if key == "no_category":
                 alias = "no_categories"
             if key == "no_class_":

--- a/caldav/search.py
+++ b/caldav/search.py
@@ -10,6 +10,7 @@ from typing import Optional
 from icalendar import Timezone
 from icalendar.prop import TypesFactory
 from icalendar_searcher import Searcher
+from icalendar_searcher.collation import Collation
 from lxml import etree
 
 from .calendarobjectresource import CalendarObjectResource
@@ -25,6 +26,40 @@ from .lib import error
 TypesFactory = TypesFactory()
 
 
+def _collation_to_caldav(collation: Collation, case_sensitive: bool = True) -> str:
+    """Map icalendar-searcher Collation enum to CalDAV collation identifier.
+
+    CalDAV supports collation identifiers from RFC 4790. The default is "i;ascii-casemap"
+    and servers must support at least "i;ascii-casemap" and "i;octet".
+
+    :param collation: icalendar-searcher Collation enum value
+    :param case_sensitive: Whether the collation should be case-sensitive
+    :return: CalDAV collation identifier string
+    """
+    if collation == Collation.SIMPLE:
+        # SIMPLE collation maps to CalDAV's basic collations
+        if case_sensitive:
+            return "i;octet"
+        else:
+            return "i;ascii-casemap"
+    elif collation == Collation.UNICODE:
+        # Unicode Collation Algorithm - not all servers support this
+        # Note: "i;unicode-casemap" is case-insensitive by definition
+        # For case-sensitive Unicode, we fall back to i;octet (binary)
+        if case_sensitive:
+            return "i;octet"
+        else:
+            return "i;unicode-casemap"
+    elif collation == Collation.LOCALE:
+        # Locale-specific collation - not widely supported in CalDAV
+        # Fallback to i;ascii-casemap as most servers don't support locale-specific collations
+        return "i;ascii-casemap"
+    else:
+        # Default to binary/octet for unknown collations
+        return "i;octet"
+
+
+@dataclass
 class CalDAVSearcher(Searcher):
     """The baseclass (which is generic, and not CalDAV-specific)
     allows building up a search query search logic.
@@ -66,9 +101,7 @@ class CalDAVSearcher(Searcher):
     ``searcher.add_property_filter``.
     """
 
-    def __init__(self, comp_class: "CalendarObjectResource" = None, **kwargs) -> None:
-        self.comp_class = comp_class
-        super().__init__(**kwargs)
+    comp_class: Optional["CalendarObjectResource"] = None
 
     def _search_with_comptypes(
         self,
@@ -86,13 +119,13 @@ class CalDAVSearcher(Searcher):
             raise NotImplementedError(
                 "full xml given, and it has to be patched to include comp_type"
             )
-        clone = replace(self)
         objects = []
+        assert self.event is None and self.todo is None and self.journal is None
         for comp_class in (Event, Todo, Journal):
+            clone = replace(self)
             clone.comp_class = comp_class
             objects += clone.search(calendar, server_expand, split_expanded, props, xml)
-        self.sort_objects(objects)
-        return objects
+        return self.sort(objects)
 
     ## TODO: refactor, split more logic out in smaller methods
     def search(
@@ -143,7 +176,11 @@ class CalDAVSearcher(Searcher):
         """
         ## Setting default value for post_filter
         if post_filter is None and (
-            (self.todo and not self.include_completed or self.expand)
+            (self.todo and not self.include_completed)
+            or self.expand
+            or "categories" in self._property_filters
+            or "category" in self._property_filters
+            or not calendar.client.features.is_supported("search.text.case-sensitive")
         ):
             post_filter = True
 
@@ -155,16 +192,38 @@ class CalDAVSearcher(Searcher):
             if not self.start or not self.end:
                 raise error.ReportError("can't expand without a date range")
 
+        ## special compatbility-case for servers that does not
+        ## support category search properly
+        things = ("filters", "operator", "locale", "collation")
+        things = [f"_property_{thing}" for thing in things]
+        if (
+            not calendar.client.features.is_supported("search.text.category")
+            and "categories" in self._property_filters
+            and post_filter is not False
+        ):
+            replacements = {}
+            for thing in things:
+                replacements[thing] = getattr(self, thing).copy()
+                replacements[thing].pop("categories")
+            clone = replace(self, **replacements)
+            objects = clone.search(calendar, server_expand, split_expanded, props, xml)
+            return self.filter(objects, post_filter, split_expanded, server_expand)
+
         ## special compatibility-case for servers that does not
         ## support combined searches very well
         if not calendar.client.features.is_supported("search.combined-is-logical-and"):
+            replacements = {}
+            for thing in things:
+                replacements[thing] = {}
             if self.start or self.end:
                 if self._property_filters:
-                    clone = replace(self, _property_filters={})
+                    clone = replace(self, **replacements)
                     objects = clone.search(
                         calendar, server_expand, split_expanded, props, xml
                     )
-                    return self.filter(objects)
+                    return self.filter(
+                        objects, post_filter, split_expanded, server_expand
+                    )
 
         ## special compatibility-case when searching for pending todos
         if self.todo and not self.include_completed:
@@ -309,10 +368,50 @@ class CalDAVSearcher(Searcher):
 
         ## Google sometimes returns empty objects
         objects = [o for o in objects if o.has_component()]
+        objects = self.filter(objects, post_filter, split_expanded, server_expand)
 
-        ## Client side filtering - in case server returned too much.
-        ## Also needed to deal with == operator
-        ## Also fixes expanding
+        ## partial workaround for https://github.com/python-caldav/caldav/issues/201
+        for obj in objects:
+            try:
+                obj.load(only_if_unloaded=True)
+            except:
+                pass
+
+        return self.sort(objects)
+
+    def filter(
+        self,
+        objects: List[CalendarObjectResource],
+        post_filter: Optional[bool] = None,
+        split_expanded: bool = True,
+        server_expand: bool = False,
+    ) -> List[CalendarObjectResource]:
+        """Apply client-side filtering and handle recurrence expansion/splitting.
+
+        This method performs client-side filtering of calendar objects, handles
+        recurrence expansion, and splits expanded recurrences into separate objects
+        when requested.
+
+        :param objects: List of Event/Todo/Journal objects to filter
+        :param post_filter: Whether to apply the searcher's filter logic.
+            - True: Always apply filters (check_component)
+            - False: Never apply filters, only handle splitting
+            - None: Use default behavior (depends on self.expand and other flags)
+        :param split_expanded: Whether to split recurrence sets into multiple
+            separate CalendarObjectResource objects. If False, a recurrence set
+            will be contained in a single object with multiple subcomponents.
+        :param server_expand: Indicates that the server was supposed to expand
+            recurrences. If True and split_expanded is True, splitting will be
+            performed even without self.expand being set.
+        :return: Filtered and/or split list of CalendarObjectResource objects
+
+        The method handles:
+        - Client-side filtering when server returns too many results
+        - Exact match filtering (== operator)
+        - Recurrence expansion via self.check_component
+        - Splitting expanded recurrences into separate objects
+        - Preserving VTIMEZONE components when splitting
+        """
         if post_filter or self.expand or (split_expanded and server_expand):
             objects_ = objects
             objects = []
@@ -328,7 +427,7 @@ class CalDAVSearcher(Searcher):
                         if not isinstance(x, Timezone)
                     ]
                 i = o.icalendar_instance
-                tz_ = [x for x in i if isinstance(x, Timezone)]
+                tz_ = [x for x in i.subcomponents if isinstance(x, Timezone)]
                 i.subcomponents = tz_
                 for comp in filtered:
                     if isinstance(comp, Timezone):
@@ -345,15 +444,6 @@ class CalDAVSearcher(Searcher):
                     new_i.add_component(comp)
                 if not (split_expanded):
                     objects.append(o)
-
-        ## partial workaround for https://github.com/python-caldav/caldav/issues/201
-        for obj in objects:
-            try:
-                obj.load(only_if_unloaded=True)
-            except:
-                pass
-
-        self.sort_objects(objects)
         return objects
 
     def build_search_xml_query(
@@ -477,17 +567,40 @@ class CalDAVSearcher(Searcher):
         for property in self._property_operator:
             if self._property_operator[property] == "undef":
                 match = cdav.NotDefined()
+                filters.append(cdav.PropFilter(property.upper()) + match)
             else:
-                ## Perhaps this replacement is wrong.
-                ## Ref RFC5545 section 3.3.11, the comma (without backslash)
-                ## basically means the text field should be considered to contain
-                ## multiple values
-                ## TODO - TODO - TODO ... this replace-logic is weird, there may be other
-                ## dragons here
-                match = cdav.TextMatch(
-                    self._property_filters[property].to_ical().replace(b"\\,", b",")
-                )
-            filters.append(cdav.PropFilter(property.upper()) + match)
+                value = self._property_filters[property]
+                property_ = property.upper()
+                if property.lower() == "category":
+                    property_ = "CATEGORIES"
+                if property.lower() == "categories":
+                    values = value.cats
+                else:
+                    values = [value]
+
+                for value in values:
+                    if hasattr(value, "to_ical"):
+                        value = value.to_ical()
+
+                    # Get collation setting for this property if available
+                    collation_str = "i;octet"  # Default to binary
+                    if (
+                        hasattr(self, "_property_collation")
+                        and property in self._property_collation
+                    ):
+                        case_sensitive = self._property_case_sensitive.get(
+                            property, True
+                        )
+                        collation_str = _collation_to_caldav(
+                            self._property_collation[property], case_sensitive
+                        )
+
+                    match = cdav.TextMatch(value, collation=collation_str)
+                    if "False" in str(match) or "True" in str(match):
+                        import pdb
+
+                        pdb.set_trace()
+                    filters.append(cdav.PropFilter(property_) + match)
 
         if comp_filter and filters:
             comp_filter += filters
@@ -502,8 +615,3 @@ class CalDAVSearcher(Searcher):
         root = cdav.CalendarQuery() + [prop, filter]
 
         return (root, self.comp_class)
-
-    ## TODO: move to base class
-    def sort_objects(self, objects):
-        if self._sort_keys:
-            objects.sort(key=self.sorting_value)

--- a/examples/collation_usage.py
+++ b/examples/collation_usage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""
+Example demonstrating case-sensitive and case-insensitive calendar searches.
+
+This example shows how to perform text searches on calendar events with
+different case sensitivity settings. The collation settings are automatically
+passed to the CalDAV server.
+"""
+import sys
+from datetime import datetime
+
+sys.path.insert(0, "..")
+sys.path.insert(0, ".")
+
+from caldav.davclient import get_davclient
+from caldav.search import CalDAVSearcher
+
+
+def run_examples():
+    """Run all examples with a real CalDAV server."""
+    print("=" * 80)
+    print("CalDAV Case-Sensitive and Case-Insensitive Search Examples")
+    print("=" * 80)
+
+    with get_davclient() as client:
+        calendar = client.principal().calendars()[0]
+
+        # Create some test events with different cases
+        print("\nCreating test events...")
+        calendar.save_event(
+            dtstart=datetime(2025, 6, 1, 10, 0),
+            dtend=datetime(2025, 6, 1, 11, 0),
+            summary="Team Meeting",
+        )
+        calendar.save_event(
+            dtstart=datetime(2025, 6, 2, 14, 0),
+            dtend=datetime(2025, 6, 2, 15, 0),
+            summary="team meeting",
+        )
+        calendar.save_event(
+            dtstart=datetime(2025, 6, 3, 9, 0),
+            dtend=datetime(2025, 6, 3, 10, 0),
+            summary="MEETING with clients",
+            location="Conference Room A",
+        )
+
+        # Example 1: Case-sensitive search (default)
+        print("\n" + "=" * 80)
+        print("Example 1: Case-Sensitive Search (Default)")
+        print("=" * 80)
+        print("Using calendar.search() - default is case-sensitive")
+        events = calendar.search(
+            start=datetime(2025, 6, 1),
+            end=datetime(2025, 6, 30),
+            event=True,
+            summary="meeting",  # Only matches lowercase "meeting"
+        )
+        print(f"Found {len(events)} event(s) matching 'meeting' (case-sensitive)")
+        for event in events:
+            print(f"  - {event.icalendar_component['SUMMARY']}")
+
+        # Example 2: Case-insensitive search using CalDAVSearcher
+        print("\n" + "=" * 80)
+        print("Example 2: Case-Insensitive Search")
+        print("=" * 80)
+        print("Using CalDAVSearcher with case_sensitive=False")
+        searcher = CalDAVSearcher(
+            event=True,
+            start=datetime(2025, 6, 1),
+            end=datetime(2025, 6, 30),
+        )
+        searcher.add_property_filter("SUMMARY", "meeting", case_sensitive=False)
+        events = searcher.search(calendar)
+        print(f"Found {len(events)} event(s) matching 'meeting' (case-insensitive)")
+        for event in events:
+            print(f"  - {event.icalendar_component['SUMMARY']}")
+
+        # Example 3: Mixed case sensitivity
+        print("\n" + "=" * 80)
+        print("Example 3: Mixed Case Sensitivity")
+        print("=" * 80)
+        print("Different properties with different case sensitivities")
+        searcher = CalDAVSearcher(
+            event=True,
+            start=datetime(2025, 6, 1),
+            end=datetime(2025, 6, 30),
+        )
+        searcher.add_property_filter("SUMMARY", "meeting", case_sensitive=True)
+        searcher.add_property_filter("LOCATION", "room", case_sensitive=False)
+
+        events = searcher.search(calendar)
+        print(
+            f"Found {len(events)} event(s) with 'meeting' (case-sensitive) in summary"
+        )
+        print(f"  AND 'room' (case-insensitive) in location")
+        for event in events:
+            comp = event.icalendar_component
+            print(f"  - {comp.get('SUMMARY', 'N/A')} @ {comp.get('LOCATION', 'N/A')}")
+
+    print("\n" + "=" * 80)
+    print("Summary:")
+    print("- By default, searches are case-sensitive")
+    print(
+        "- For case-insensitive searches, use CalDAVSearcher with case_sensitive=False"
+    )
+    print(
+        "- The CalDAVSearcher API allows mixing case sensitivities on different properties"
+    )
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    run_examples()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "recurring-ical-events>=2.0.0",
   "typing_extensions;python_version<'3.11'",
   "icalendar>6.0.0",
-  "icalendar-searcher>=0.1.1",
+  "icalendar-searcher>=1.0.0,<2",
 ]
 dynamic = ["version"]
 
@@ -55,7 +55,7 @@ test = [
   "manuel",
   "proxy.py",
   "tzlocal",
-  "xandikos",
+  "xandikos>=0.2.12",
   "radicale",
   "pyfakefs",
   #"caldav_server_tester"

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -230,7 +230,10 @@ if test_xandikos:
 
         self.serverdir.__exit__(None, None, None)
 
-    features = compatibility_hints.xandikos.copy()
+    if xandikos.__version__ == (0, 2, 12):
+        features = compatibility_hints.xandikos_v0_2_12.copy()
+    else:
+        features = compatibility_hints.xandikos_v0_3.copy()
     domain = f"{xandikos_host}:{xandikos_port}"
     features["auto-connect.url"]["domain"] = domain
     caldav_servers.append(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,3 +31,10 @@ class TestExamples:
         from examples import basic_usage_examples
 
         basic_usage_examples.run_examples()
+
+    def test_collation(self):
+        from examples import collation_usage
+
+        with get_davclient() as client:
+            mycal = client.principal().make_calendar(name="Test calendar")
+            collation_usage.run_examples()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Tests for caldav.search.CalDAVSearcher.filter method
+
+Rule: None of the tests in this file should initiate any internet
+communication. We use mocked client objects as needed.
+
+Disclaimer: AI-generated tests
+"""
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest import mock
+
+import icalendar
+import pytest
+
+from caldav import Event
+from caldav import Journal
+from caldav import Todo
+from caldav.davclient import DAVClient
+from caldav.search import CalDAVSearcher
+
+
+# Example icalendar data for testing
+SIMPLE_EVENT = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:simple-event@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240615T140000Z
+DTEND:20240615T150000Z
+SUMMARY:Simple Meeting
+END:VEVENT
+END:VCALENDAR"""
+
+RECURRING_EVENT = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:recurring-event@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240601T100000Z
+DTEND:20240601T110000Z
+SUMMARY:Weekly Standup
+RRULE:FREQ=WEEKLY;COUNT=3
+END:VEVENT
+END:VCALENDAR"""
+
+RECURRING_EVENT_WITH_TIMEZONE = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:STANDARD
+DTSTART:20231105T020000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20240310T020000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:tz-event@example.com
+DTSTAMP:20240101T120000Z
+DTSTART;TZID=America/New_York:20240601T090000
+DTEND;TZID=America/New_York:20240601T100000
+SUMMARY:Morning Meeting
+RRULE:FREQ=DAILY;COUNT=3
+END:VEVENT
+END:VCALENDAR"""
+
+SIMPLE_TODO = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTODO
+UID:simple-todo@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240610T100000Z
+DUE:20240620T170000Z
+SUMMARY:Complete project proposal
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR"""
+
+COMPLETED_TODO = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTODO
+UID:completed-todo@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240601T100000Z
+DUE:20240605T170000Z
+COMPLETED:20240604T150000Z
+SUMMARY:Submit report
+STATUS:COMPLETED
+END:VTODO
+END:VCALENDAR"""
+
+RECURRING_TODO = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTODO
+UID:recurring-todo@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240601T080000Z
+DUE:20240601T090000Z
+SUMMARY:Daily review
+RRULE:FREQ=DAILY;COUNT=5
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR"""
+
+SIMPLE_JOURNAL = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VJOURNAL
+UID:simple-journal@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240615T190000Z
+SUMMARY:Daily notes
+DESCRIPTION:Today's reflections
+END:VJOURNAL
+END:VCALENDAR"""
+
+# Event with categories for filter testing
+CATEGORIZED_EVENT = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:categorized-event@example.com
+DTSTAMP:20240101T120000Z
+DTSTART:20240615T140000Z
+DTEND:20240615T150000Z
+SUMMARY:Team Building
+CATEGORIES:WORK,SOCIAL
+END:VEVENT
+END:VCALENDAR"""
+
+
+@pytest.fixture
+def mock_client() -> DAVClient:
+    """Create a mocked DAV client for testing."""
+    return mock.Mock(spec=DAVClient)
+
+
+@pytest.fixture
+def mock_url() -> str:
+    """Return a mocked URL for test objects."""
+    return "https://calendar.example.com/calendars/user/event.ics"
+
+
+class TestCalDAVSearcherFilterBasic:
+    """Basic tests for CalDAVSearcher.filter without filtering logic."""
+
+    def test_filter_with_no_filtering_returns_same_objects(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When post_filter=False and no expansion, objects should pass through unchanged."""
+        event1 = Event(client=mock_client, url=mock_url + "/1", data=SIMPLE_EVENT)
+        event2 = Event(client=mock_client, url=mock_url + "/2", data=SIMPLE_EVENT)
+        objects = [event1, event2]
+
+        searcher = CalDAVSearcher()
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=False, server_expand=False
+        )
+
+        assert len(result) == 2
+        assert result[0] is event1
+        assert result[1] is event2
+
+    def test_filter_with_empty_list_returns_empty(self, mock_client: DAVClient) -> None:
+        """Filtering an empty list should return an empty list."""
+        searcher = CalDAVSearcher()
+        result = searcher.filter(
+            [], post_filter=False, split_expanded=False, server_expand=False
+        )
+
+        assert result == []
+
+    def test_filter_preserves_object_types(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Filter should work with Event, Todo, and Journal objects."""
+        event = Event(client=mock_client, url=mock_url + "/event", data=SIMPLE_EVENT)
+        todo = Todo(client=mock_client, url=mock_url + "/todo", data=SIMPLE_TODO)
+        journal = Journal(
+            client=mock_client, url=mock_url + "/journal", data=SIMPLE_JOURNAL
+        )
+
+        objects = [event, todo, journal]
+        searcher = CalDAVSearcher()
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=False, server_expand=False
+        )
+
+        assert len(result) == 3
+        assert isinstance(result[0], Event)
+        assert isinstance(result[1], Todo)
+        assert isinstance(result[2], Journal)
+
+
+class TestCalDAVSearcherFilterPostFilter:
+    """Tests for post_filter parameter functionality."""
+
+    def test_filter_with_post_filter_true_applies_filters(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When post_filter=True, searcher filter logic should be applied."""
+        # Create a searcher with a summary filter
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+        searcher.add_property_filter("SUMMARY", "Meeting", operator="contains")
+
+        event1 = Event(
+            client=mock_client, url=mock_url + "/1", data=SIMPLE_EVENT
+        )  # "Simple Meeting"
+        event2 = Event(
+            client=mock_client, url=mock_url + "/2", data=CATEGORIZED_EVENT
+        )  # "Team Building"
+
+        objects = [event1, event2]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=False, server_expand=False
+        )
+
+        # Only event1 should match (contains "Meeting")
+        assert len(result) == 1
+        assert "Meeting" in result[0].icalendar_component.get("SUMMARY")
+
+    def test_filter_with_post_filter_false_skips_filters(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When post_filter=False, filter logic should be skipped."""
+        # Create a searcher with a summary filter
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+        searcher.add_property_filter("SUMMARY", "Meeting", operator="contains")
+
+        event1 = Event(client=mock_client, url=mock_url + "/1", data=SIMPLE_EVENT)
+        event2 = Event(client=mock_client, url=mock_url + "/2", data=CATEGORIZED_EVENT)
+
+        objects = [event1, event2]
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=False, server_expand=False
+        )
+
+        # Both events should be returned without filtering
+        assert len(result) == 2
+
+    def test_filter_completed_todos_with_post_filter(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """post_filter should filter out completed todos when include_completed=False."""
+        searcher = CalDAVSearcher(
+            todo=True,
+            include_completed=False,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        todo1 = Todo(
+            client=mock_client, url=mock_url + "/1", data=SIMPLE_TODO
+        )  # NEEDS-ACTION
+        todo2 = Todo(
+            client=mock_client, url=mock_url + "/2", data=COMPLETED_TODO
+        )  # COMPLETED
+
+        objects = [todo1, todo2]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=False, server_expand=False
+        )
+
+        # Only the non-completed todo should be returned
+        assert len(result) == 1
+        assert result[0].icalendar_component.get("STATUS") == "NEEDS-ACTION"
+
+
+class TestCalDAVSearcherFilterExpand:
+    """Tests for expand functionality with split_expanded parameter."""
+
+    def test_filter_with_expand_splits_recurrences(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When expand=True and split_expanded=True, recurrences should be split into separate objects."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)  # COUNT=3
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should expand into 3 separate event objects
+        assert len(result) == 3
+        # Each should be a distinct object
+        assert result[0] is not result[1]
+        assert result[1] is not result[2]
+
+    def test_filter_with_expand_no_split_keeps_single_object(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When expand=True but split_expanded=False, recurrences should stay in one object."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)  # COUNT=3
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=False, server_expand=False
+        )
+
+        # Should return single object with multiple subcomponents
+        assert len(result) == 1
+        # The calendar should contain 3 event subcomponents (plus timezone if any)
+        event_components = [
+            c for c in result[0].icalendar_instance.subcomponents if c.name == "VEVENT"
+        ]
+        assert len(event_components) == 3
+
+    def test_filter_with_expand_preserves_timezones(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When expanding events with timezones, timezone info should be preserved."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(
+            client=mock_client, url=mock_url, data=RECURRING_EVENT_WITH_TIMEZONE
+        )
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should expand into 3 events
+        assert len(result) == 3
+
+        # Each split event should have timezone information preserved
+        for evt in result:
+            tz_components = [
+                c
+                for c in evt.icalendar_instance.subcomponents
+                if isinstance(c, icalendar.Timezone)
+            ]
+            assert len(tz_components) == 1
+            assert tz_components[0].get("TZID") == "America/New_York"
+
+    def test_filter_non_recurring_event_no_expansion(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Non-recurring events should not be expanded even with expand=True."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=SIMPLE_EVENT)
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should return single event (no expansion needed)
+        assert len(result) == 1
+
+
+class TestCalDAVSearcherFilterServerExpand:
+    """Tests for server_expand parameter handling."""
+
+    def test_filter_with_server_expand_and_split(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When server_expand=True and split_expanded=True, server-expanded results should be split."""
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        # Simulate a server-expanded event (server already expanded recurring event)
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=True, server_expand=True
+        )
+
+        # Even without post_filter, server_expand + split_expanded should cause splitting
+        # The recurring event should be treated as if server expanded it
+        assert len(result) >= 1
+
+    def test_filter_with_server_expand_no_split(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When server_expand=True but split_expanded=False, results should not be split."""
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=False, server_expand=True
+        )
+
+        # Should remain as single object
+        assert len(result) == 1
+
+
+class TestCalDAVSearcherFilterRecurringTodos:
+    """Tests for recurring todo handling in filter."""
+
+    def test_filter_recurring_todo_with_expand(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Recurring todos should be expanded when expand=True."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        todo = Todo(
+            client=mock_client, url=mock_url, data=RECURRING_TODO
+        )  # FREQ=DAILY;COUNT=5
+
+        objects = [todo]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should expand into 5 separate todo objects
+        assert len(result) == 5
+
+    def test_filter_recurring_todo_filters_completed(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Recurring todos with completed instances should be filtered when include_completed=False."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            todo=True,
+            include_completed=False,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        # Create a recurring todo that has some completed instances
+        # (In reality, this would be tested with actual recurrence exceptions)
+        todo = Todo(client=mock_client, url=mock_url, data=RECURRING_TODO)
+
+        objects = [todo]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # All results should be non-completed
+        for t in result:
+            status = t.icalendar_component.get("STATUS")
+            assert status != "COMPLETED"
+
+
+class TestCalDAVSearcherFilterEdgeCases:
+    """Tests for edge cases and combinations of parameters."""
+
+    def test_filter_with_all_params_false(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When all filter params are False/None, objects should pass through."""
+        searcher = CalDAVSearcher()
+
+        event = Event(client=mock_client, url=mock_url, data=SIMPLE_EVENT)
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=False, split_expanded=False, server_expand=False
+        )
+
+        assert len(result) == 1
+        assert result[0] is event
+
+    def test_filter_mixed_object_types_with_expand(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Filter should handle mixed object types (Event, Todo) with expansion."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(
+            client=mock_client, url=mock_url + "/event", data=RECURRING_EVENT
+        )  # 3 occurrences
+        todo = Todo(
+            client=mock_client, url=mock_url + "/todo", data=RECURRING_TODO
+        )  # 5 occurrences
+
+        objects = [event, todo]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should expand both: 3 events + 5 todos = 8 total
+        assert len(result) == 8
+
+    def test_filter_with_expand_but_no_date_range(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Expansion with limited COUNT should work even without explicit date range."""
+        # Using expand without start/end is risky but should work with COUNT-based rules
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 7, 1, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should handle expansion properly
+        assert len(result) == 3
+
+    def test_filter_preserves_uid_in_split_events(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Split expanded events should preserve the original UID."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)
+        original_uid = event.icalendar_component.get("UID")
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # All split events should have the same UID
+        for evt in result:
+            assert evt.icalendar_component.get("UID") == original_uid
+
+    def test_filter_with_post_filter_none_uses_default(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """When post_filter=None, default behavior should be applied."""
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event = Event(client=mock_client, url=mock_url, data=SIMPLE_EVENT)
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=None, split_expanded=False, server_expand=False
+        )
+
+        # Should handle None gracefully (no filtering unless triggered by other params)
+        assert len(result) == 1
+
+    def test_filter_complex_scenario_expand_filter_split(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Complex scenario: expand + post_filter + split_expanded all True."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+        searcher.add_property_filter("SUMMARY", "Standup", operator="contains")
+
+        event = Event(
+            client=mock_client, url=mock_url, data=RECURRING_EVENT
+        )  # "Weekly Standup"
+
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # Should expand, filter, and split
+        assert len(result) == 3  # 3 occurrences, all matching filter
+        for evt in result:
+            assert "Standup" in evt.icalendar_component.get("SUMMARY")
+            assert evt.icalendar_component.get("RECURRENCE-ID") is not None
+
+
+class TestCalDAVSearcherFilterIntegration:
+    """Integration-style tests combining multiple features."""
+
+    def test_filter_workflow_server_side_then_client_side(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Simulate server-side expand followed by client-side filtering and splitting."""
+        # Step 1: Server expands (simulated by having recurring event)
+        searcher = CalDAVSearcher(
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+        searcher.add_property_filter("SUMMARY", "Weekly", operator="contains")
+
+        event = Event(client=mock_client, url=mock_url, data=RECURRING_EVENT)
+
+        # Step 2: Client-side filter with server_expand=True
+        objects = [event]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=True
+        )
+
+        # Should handle both server expansion and client-side filtering
+        assert len(result) >= 1
+
+    def test_filter_multiple_events_different_recurrence_patterns(
+        self, mock_client: DAVClient, mock_url: str
+    ) -> None:
+        """Test filtering multiple events with different recurrence patterns."""
+        searcher = CalDAVSearcher(
+            expand=True,
+            start=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 6, 30, tzinfo=timezone.utc),
+        )
+
+        event1 = Event(
+            client=mock_client, url=mock_url + "/1", data=RECURRING_EVENT
+        )  # Weekly, 3 times
+        event2 = Event(
+            client=mock_client, url=mock_url + "/2", data=SIMPLE_EVENT
+        )  # No recurrence
+
+        objects = [event1, event2]
+        result = searcher.filter(
+            objects, post_filter=True, split_expanded=True, server_expand=False
+        )
+
+        # 3 recurring + 1 simple = 4 total
+        assert len(result) == 4

--- a/tests/test_search_collation.py
+++ b/tests/test_search_collation.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Tests for caldav.search.CalDAVSearcher collation support
+
+Tests that verify collation attributes are correctly passed from
+icalendar-searcher to CalDAV XML queries.
+"""
+import pytest
+from icalendar_searcher.collation import Collation
+
+from caldav.search import _collation_to_caldav
+from caldav.search import CalDAVSearcher
+
+
+def test_collation_to_caldav_simple_case_sensitive() -> None:
+    """Test mapping from Collation.SIMPLE (case-sensitive) to CalDAV i;octet."""
+    assert _collation_to_caldav(Collation.SIMPLE, case_sensitive=True) == "i;octet"
+
+
+def test_collation_to_caldav_simple_case_insensitive() -> None:
+    """Test mapping from Collation.SIMPLE (case-insensitive) to CalDAV i;ascii-casemap."""
+    assert (
+        _collation_to_caldav(Collation.SIMPLE, case_sensitive=False)
+        == "i;ascii-casemap"
+    )
+
+
+def test_collation_to_caldav_unicode_case_sensitive() -> None:
+    """Test mapping from Collation.UNICODE (case-sensitive) to CalDAV i;octet."""
+    assert _collation_to_caldav(Collation.UNICODE, case_sensitive=True) == "i;octet"
+
+
+def test_collation_to_caldav_unicode_case_insensitive() -> None:
+    """Test mapping from Collation.UNICODE (case-insensitive) to CalDAV i;unicode-casemap."""
+    assert (
+        _collation_to_caldav(Collation.UNICODE, case_sensitive=False)
+        == "i;unicode-casemap"
+    )
+
+
+def test_collation_to_caldav_locale() -> None:
+    """Test mapping from Collation.LOCALE to CalDAV fallback."""
+    # Locale-specific collations are not widely supported in CalDAV,
+    # so we fall back to i;ascii-casemap
+    assert _collation_to_caldav(Collation.LOCALE) == "i;ascii-casemap"
+
+
+def test_build_search_xml_query_default_collation() -> None:
+    """Test that build_search_xml_query uses default binary collation when not specified."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter("SUMMARY", "test")
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;octet collation (binary/case-sensitive)
+    assert 'collation="i;octet"' in xml_str
+
+
+def test_build_search_xml_query_case_insensitive_collation() -> None:
+    """Test that build_search_xml_query uses i;ascii-casemap for case-insensitive searches."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter("SUMMARY", "test", case_sensitive=False)
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation (case-insensitive)
+    assert 'collation="i;ascii-casemap"' in xml_str
+
+
+def test_build_search_xml_query_explicit_simple_case_sensitive_collation() -> None:
+    """Test that build_search_xml_query respects explicit SIMPLE collation with case_sensitive=True."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter(
+        "SUMMARY", "test", collation=Collation.SIMPLE, case_sensitive=True
+    )
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;octet collation
+    assert 'collation="i;octet"' in xml_str
+
+
+def test_build_search_xml_query_explicit_simple_case_insensitive_collation() -> None:
+    """Test that build_search_xml_query respects explicit SIMPLE collation with case_sensitive=False."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter(
+        "SUMMARY", "test", collation=Collation.SIMPLE, case_sensitive=False
+    )
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation
+    assert 'collation="i;ascii-casemap"' in xml_str
+
+
+def test_build_search_xml_query_unicode_collation() -> None:
+    """Test that build_search_xml_query uses i;unicode-casemap for UNICODE collation (case-insensitive)."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter(
+        "SUMMARY", "test", collation=Collation.UNICODE, case_sensitive=False
+    )
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;unicode-casemap collation
+    assert 'collation="i;unicode-casemap"' in xml_str
+
+
+def test_build_search_xml_query_locale_collation() -> None:
+    """Test that build_search_xml_query falls back to i;ascii-casemap for LOCALE collation."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter(
+        "SUMMARY", "test", collation=Collation.LOCALE, locale="de_DE"
+    )
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation (fallback)
+    assert 'collation="i;ascii-casemap"' in xml_str
+
+
+def test_build_search_xml_query_multiple_properties_different_collations() -> None:
+    """Test that different properties can have different collations."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter("SUMMARY", "test", case_sensitive=True)  # Binary
+    searcher.add_property_filter(
+        "LOCATION", "room", case_sensitive=False
+    )  # Case-insensitive
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain both collations
+    assert 'collation="i;octet"' in xml_str
+    assert 'collation="i;ascii-casemap"' in xml_str
+
+
+def test_build_search_xml_query_collation_with_case_sensitive() -> None:
+    """Test that case_sensitive parameter works with explicit collation."""
+    searcher = CalDAVSearcher(event=True)
+    # SIMPLE collation with case_sensitive=True should use i;octet
+    searcher.add_property_filter(
+        "SUMMARY", "test", case_sensitive=True, collation=Collation.SIMPLE
+    )
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should use i;octet (case-sensitive)
+    assert 'collation="i;octet"' in xml_str
+
+
+def test_build_search_xml_query_todo_with_collation() -> None:
+    """Test that collation works with todo searches."""
+    searcher = CalDAVSearcher(todo=True)
+    searcher.add_property_filter("SUMMARY", "task", case_sensitive=False)
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation
+    assert 'collation="i;ascii-casemap"' in xml_str
+    # Should be a VTODO query
+    assert "VTODO" in xml_str
+
+
+def test_build_search_xml_query_journal_with_collation() -> None:
+    """Test that collation works with journal searches."""
+    searcher = CalDAVSearcher(journal=True)
+    searcher.add_property_filter("SUMMARY", "note", case_sensitive=False)
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation
+    assert 'collation="i;ascii-casemap"' in xml_str
+    # Should be a VJOURNAL query
+    assert "VJOURNAL" in xml_str
+
+
+def test_build_search_xml_query_description_with_collation() -> None:
+    """Test that collation works with DESCRIPTION property."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter("DESCRIPTION", "important", case_sensitive=False)
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation
+    assert 'collation="i;ascii-casemap"' in xml_str
+    # Should have DESCRIPTION property filter
+    assert "DESCRIPTION" in xml_str
+
+
+def test_build_search_xml_query_categories_with_collation() -> None:
+    """Test that collation works with CATEGORIES property."""
+    searcher = CalDAVSearcher(event=True)
+    searcher.add_property_filter("CATEGORIES", "work", case_sensitive=False)
+
+    xml, comp_class = searcher.build_search_xml_query()
+    xml_str = str(xml)
+
+    # Should contain text-match with i;ascii-casemap collation
+    assert 'collation="i;ascii-casemap"' in xml_str
+    # Should have CATEGORIES property filter
+    assert "CATEGORIES" in xml_str

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py37,py38,py39,py310,py311,py312,py313,py314,docs,style
+envlist = y39,py310,py311,py312,py313,py314,docs,style
 
 [testenv]
 deps = --editable .[test]


### PR DESCRIPTION
* Implemented workarounds in the search for many server compatibility issues.  Now it's possible to do quite much filtering logic on the client-side.
* Collation was glossed over earlier, support has been improved.  It's now possible to specify if a search should be case-insensitive or case-sensitive, but as for now the case-insensitivity is only guaranteed to work for the ASCII characters.
* Quite some logic "Search for ZZZ - if server supports XXX, then assert YYY" in the test code has been replaced with just "Search for ZZZ - assert YYY"
* This should fix https://github.com/python-caldav/caldav/issues/434
* Been working more on the "compatibility hints" database
 * Now there is a difference between searching for a "category" string vs a "categories" set. 

The case-insensitive searches may be improved more; I made a new issue https://github.com/python-caldav/caldav/issues/567
