### PR TITLE
Add automated Nextcloud CalDAV/CardDAV testing framework

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,19 @@ jobs:
           --health-timeout 5s
           --health-retries 5
           --health-start-period 30s
+      nextcloud:
+        image: nextcloud:latest
+        ports:
+          - 8801:80
+        env:
+          NEXTCLOUD_ADMIN_USER: admin
+          NEXTCLOUD_ADMIN_PASSWORD: admin
+        options: >-
+          --health-cmd "curl -f http://localhost/status.php || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --health-start-period 60s
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -51,9 +64,32 @@ jobs:
           sleep 5
           timeout 60 bash -c 'until curl -f http://localhost:8800/ 2>/dev/null; do echo "Waiting..."; sleep 2; done'
           echo "Baikal is ready!"
+      - name: Configure Nextcloud
+        run: |
+          # Wait for Nextcloud to be ready
+          timeout 120 bash -c 'until docker exec ${{ job.services.nextcloud.id }} php occ status 2>/dev/null | grep -q "installed: true"; do echo "Waiting for Nextcloud..."; sleep 2; done'
+          echo "Nextcloud is ready"
+
+          # Disable password policy
+          docker exec ${{ job.services.nextcloud.id }} php occ app:disable password_policy || true
+
+          # Create test user
+          docker exec -e OC_PASS="TestPassword123!" ${{ job.services.nextcloud.id }} php occ user:add --password-from-env --display-name="Test User" testuser || echo "User may already exist"
+
+          # Enable calendar and contacts apps
+          docker exec ${{ job.services.nextcloud.id }} php occ app:enable calendar || true
+          docker exec ${{ job.services.nextcloud.id }} php occ app:enable contacts || true
+
+          # Disable rate limiting and bruteforce protection
+          docker exec ${{ job.services.nextcloud.id }} php occ config:system:set ratelimit.enabled --value=false --type=boolean || true
+          docker exec ${{ job.services.nextcloud.id }} php occ app:disable bruteforcesettings || true
+          docker exec ${{ job.services.nextcloud.id }} php occ config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean || true
+
+          echo "Nextcloud is configured!"
       - run: tox -e py
         env:
           BAIKAL_URL: http://localhost:8800
+          NEXTCLOUD_URL: http://localhost:8801
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,9 +66,30 @@ jobs:
           echo "Baikal is ready!"
       - name: Configure Nextcloud
         run: |
-          # Wait for Nextcloud to be ready
-          timeout 120 bash -c 'until docker exec ${{ job.services.nextcloud.id }} php occ status 2>/dev/null | grep -q "installed: true"; do echo "Waiting for Nextcloud..."; sleep 2; done'
-          echo "Nextcloud is ready"
+          # Wait for Nextcloud web server to be up
+          echo "Waiting for Nextcloud web server..."
+          timeout 60 bash -c 'until curl -f http://localhost:8801/status.php 2>/dev/null; do echo -n "."; sleep 2; done'
+          echo ""
+          echo "✓ Web server is up"
+
+          # Wait for Nextcloud to be installed (first startup takes longer)
+          echo "Waiting for Nextcloud to complete installation..."
+          for i in {1..180}; do
+            if docker exec ${{ job.services.nextcloud.id }} php occ status 2>/dev/null | grep -q "installed: true"; then
+              echo "✓ Nextcloud is installed and ready"
+              break
+            fi
+            if [ $i -eq 180 ]; then
+              echo "✗ Nextcloud did not complete installation in time"
+              echo "Container logs:"
+              docker logs ${{ job.services.nextcloud.id }} | tail -100
+              echo "Trying to run occ status:"
+              docker exec ${{ job.services.nextcloud.id }} php occ status || true
+              exit 1
+            fi
+            echo -n "."
+            sleep 2
+          done
 
           # Disable password policy
           docker exec ${{ job.services.nextcloud.id }} php occ app:disable password_policy || true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,6 +85,22 @@ jobs:
           docker exec ${{ job.services.nextcloud.id }} php occ app:disable bruteforcesettings || true
           docker exec ${{ job.services.nextcloud.id }} php occ config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean || true
 
+          # Configure CalDAV rate limits
+          docker exec ${{ job.services.nextcloud.id }} php occ config:app:set dav rateLimitCalendarCreation --value=99999 || true
+          docker exec ${{ job.services.nextcloud.id }} php occ config:app:set dav maximumCalendarsSubscriptions --value=-1 || true
+
+          # Add IP whitelist for rate limiting
+          docker exec ${{ job.services.nextcloud.id }} php occ config:system:set ratelimit.whitelist.0 --value='172.17.0.0/16' || true
+          docker exec ${{ job.services.nextcloud.id }} php occ config:system:set ratelimit.whitelist.1 --value='127.0.0.1' || true
+
+          # Clear rate limit cache
+          docker exec ${{ job.services.nextcloud.id }} php -r "
+          \$db = new PDO('sqlite:/var/www/html/data/nextcloud.db');
+          \$db->exec('DELETE FROM oc_ratelimit_entries');
+          \$db->exec('DELETE FROM oc_bruteforce_attempts');
+          echo 'Cleared rate limit and bruteforce caches\n';
+          " || true
+
           echo "Nextcloud is configured!"
       - run: tox -e py
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,24 +72,17 @@ jobs:
           echo ""
           echo "✓ Web server is up"
 
-          # Wait for Nextcloud to be installed (first startup takes longer)
-          echo "Waiting for Nextcloud to complete installation..."
-          for i in {1..180}; do
-            if docker exec ${{ job.services.nextcloud.id }} php occ status 2>/dev/null | grep -q "installed: true"; then
-              echo "✓ Nextcloud is installed and ready"
-              break
-            fi
-            if [ $i -eq 180 ]; then
-              echo "✗ Nextcloud did not complete installation in time"
-              echo "Container logs:"
-              docker logs ${{ job.services.nextcloud.id }} | tail -100
-              echo "Trying to run occ status:"
-              docker exec ${{ job.services.nextcloud.id }} php occ status || true
-              exit 1
-            fi
-            echo -n "."
-            sleep 2
-          done
+          # Install Nextcloud if not already installed
+          if ! docker exec ${{ job.services.nextcloud.id }} php occ status 2>/dev/null | grep -q "installed: true"; then
+            echo "Installing Nextcloud..."
+            docker exec ${{ job.services.nextcloud.id }} php occ maintenance:install \
+              --database=sqlite \
+              --admin-user=admin \
+              --admin-pass=admin
+            echo "✓ Nextcloud installed"
+          else
+            echo "✓ Nextcloud is already installed"
+          fi
 
           # Disable password policy
           docker exec ${{ job.services.nextcloud.id }} php occ app:disable password_policy || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Also, the RFC6764 discovery may not always be robust, causing fallbacks and henc
   - `i;unicode-casemap` (Unicode case-insensitive, RFC 5051 - server support may vary)
 * Client-side filtering method: `CalDAVSearcher.filter()` provides comprehensive client-side filtering, expansion, and sorting of calendar objects with full timezone preservation support.
 * Example code: New `examples/collation_usage.py` demonstrates case-sensitive and case-insensitive calendar searches.
+* **Automated Nextcloud Docker testing framework**: Complete automated testing setup for Nextcloud CalDAV/CardDAV server using Docker containers with SQLite backend. Provides real-world testing coverage against one of the most popular cloud platforms.
+  - Automatic container lifecycle management with user provisioning
+  - Uses official Nextcloud Docker image with automated setup script
+  - Auto-appends `/remote.php/dav` to base URL for correct CalDAV endpoint
+  - Creates test user and enables calendar/contacts apps automatically
+  - Graceful degradation on systems without Docker
+  - Compatible with existing Nextcloud compatibility hints
 
 ### Test suite
 

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -546,10 +546,11 @@ if test_nextcloud:
         # Run setup script to configure Nextcloud and create test user
         print("Configuring Nextcloud...")
         setup_script = nextcloud_dir / "setup_nextcloud.sh"
-        subprocess.run(
+        result = subprocess.run(
             [str(setup_script)],
             cwd=nextcloud_dir,
             check=True,
+            capture_output=False,
         )
 
         # Wait for Nextcloud to be ready

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -465,7 +465,11 @@ except ImportError:
                 timeout=5,
             )
             test_nextcloud = True
-        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ):
             test_nextcloud = False
 
 try:
@@ -483,9 +487,9 @@ if test_nextcloud:
         "NEXTCLOUD_URL", f"http://{nextcloud_host}:{nextcloud_port}"
     )
     # Ensure the URL includes /remote.php/dav/ for CalDAV endpoint
-    if not nextcloud_base_url.endswith("/remote.php/dav") and not nextcloud_base_url.endswith(
-        "/remote.php/dav/"
-    ):
+    if not nextcloud_base_url.endswith(
+        "/remote.php/dav"
+    ) and not nextcloud_base_url.endswith("/remote.php/dav/"):
         nextcloud_url = f"{nextcloud_base_url}/remote.php/dav"
     else:
         nextcloud_url = nextcloud_base_url.rstrip("/")
@@ -566,7 +570,9 @@ if test_nextcloud:
                 pass
             time.sleep(1)
 
-        raise TimeoutError(f"Nextcloud did not become ready after {max_attempts} seconds")
+        raise TimeoutError(
+            f"Nextcloud did not become ready after {max_attempts} seconds"
+        )
 
     def teardown_nextcloud(self) -> None:
         """Stop Nextcloud Docker container."""

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -491,7 +491,7 @@ if test_nextcloud:
         nextcloud_url = nextcloud_base_url.rstrip("/")
 
     nextcloud_username = os.environ.get("NEXTCLOUD_USERNAME", "testuser")
-    nextcloud_password = os.environ.get("NEXTCLOUD_PASSWORD", "testpass")
+    nextcloud_password = os.environ.get("NEXTCLOUD_PASSWORD", "TestPassword123!")
 
     def is_nextcloud_accessible() -> bool:
         """Check if Nextcloud server is accessible."""

--- a/tests/docker-test-servers/nextcloud/README.md
+++ b/tests/docker-test-servers/nextcloud/README.md
@@ -1,0 +1,143 @@
+# Testing with Nextcloud CalDAV Server
+
+This directory contains the Docker setup for running automated tests against a Nextcloud CalDAV/CardDAV server. The setup works seamlessly in both local development and CI/CD environments.
+
+## Requirements
+
+- **Docker** and **docker-compose** must be installed
+- If Docker is not available, Nextcloud tests will be automatically skipped
+
+## Automatic Setup
+
+**Tests automatically start Nextcloud if Docker is available!** Just run:
+
+```bash
+pytest tests/
+# or
+tox -e py
+```
+
+The test framework will:
+1. Detect if docker-compose is available
+2. Automatically start the Nextcloud container if needed
+3. Configure Nextcloud and create a test user
+4. Run tests against it
+5. Clean up after tests complete
+
+## Manual Setup (Optional)
+
+If you prefer to start Nextcloud manually:
+
+```bash
+cd tests/docker-test-servers/nextcloud
+./start.sh
+```
+
+This will:
+1. Start the Nextcloud container with SQLite backend
+2. Wait for Nextcloud to initialize (first startup takes ~1 minute)
+3. Create admin user and test user
+4. Enable calendar and contacts apps
+5. Nextcloud will be available on `http://localhost:8801`
+
+## Configuration
+
+This Nextcloud instance comes **pre-configured** with:
+- Admin user: `admin` / `admin`
+- Test user: `testuser` / `testpass`
+- Calendar and Contacts apps enabled
+- CalDAV URL: `http://localhost:8801/remote.php/dav`
+
+**No manual configuration needed!** The container will start ready to use.
+
+**Note:** The test framework automatically appends `/remote.php/dav` to the base URL, so you can set `NEXTCLOUD_URL=http://localhost:8801` and it will work correctly.
+
+## Environment Variables
+
+- `NEXTCLOUD_URL`: URL of the Nextcloud server (default: `http://localhost:8801`)
+- `NEXTCLOUD_USERNAME`: Test user username (default: `testuser`)
+- `NEXTCLOUD_PASSWORD`: Test user password (default: `testpass`)
+
+## Disabling Nextcloud Tests
+
+If you want to skip Nextcloud tests, create `tests/conf_private.py`:
+
+```python
+test_nextcloud = False
+```
+
+Or simply don't install Docker - the tests will automatically skip Nextcloud if Docker is not available.
+
+## Troubleshooting
+
+### Container won't start
+```bash
+# Check container logs
+docker-compose logs nextcloud
+
+# Restart container
+docker-compose restart nextcloud
+```
+
+### Tests can't connect to Nextcloud
+```bash
+# Check if Nextcloud is accessible
+curl -v http://localhost:8801/
+
+# Check if container is running
+docker-compose ps
+
+# Check container health
+docker inspect nextcloud-test
+```
+
+### Reset Nextcloud
+```bash
+# Stop and remove container with volumes (WARNING: deletes all data)
+docker-compose down -v
+
+# Start fresh
+./start.sh
+```
+
+## Docker Compose Commands
+
+```bash
+# Start Nextcloud in background
+docker-compose up -d
+
+# View logs
+docker-compose logs -f nextcloud
+
+# Stop Nextcloud
+docker-compose stop
+
+# Stop and remove (keeps volumes)
+docker-compose down
+
+# Stop and remove everything including data
+docker-compose down -v
+
+# Restart Nextcloud
+docker-compose restart nextcloud
+```
+
+## Architecture
+
+The Nextcloud testing framework consists of:
+
+1. **docker-compose.yml** - Defines the Nextcloud container with SQLite backend
+2. **setup_nextcloud.sh** - Configures Nextcloud and creates test user
+3. **start.sh** / **stop.sh** - Manual start/stop scripts
+4. **tests/conf.py** - Auto-detects Nextcloud and manages container lifecycle
+
+## Notes
+
+- First startup takes longer (~1 minute) as Nextcloud initializes
+- Uses SQLite for simplicity (production should use MySQL/PostgreSQL)
+- Data is persisted in a Docker volume between restarts
+- Container runs on port 8801 (to avoid conflicts with Baikal on 8800)
+
+## Version
+
+This setup uses the `nextcloud:latest` Docker image, which currently tracks the latest stable Nextcloud release.

--- a/tests/docker-test-servers/nextcloud/README.md
+++ b/tests/docker-test-servers/nextcloud/README.md
@@ -44,7 +44,7 @@ This will:
 
 This Nextcloud instance comes **pre-configured** with:
 - Admin user: `admin` / `admin`
-- Test user: `testuser` / `testpass`
+- Test user: `testuser` / `TestPassword123!`
 - Calendar and Contacts apps enabled
 - CalDAV URL: `http://localhost:8801/remote.php/dav`
 
@@ -56,7 +56,7 @@ This Nextcloud instance comes **pre-configured** with:
 
 - `NEXTCLOUD_URL`: URL of the Nextcloud server (default: `http://localhost:8801`)
 - `NEXTCLOUD_USERNAME`: Test user username (default: `testuser`)
-- `NEXTCLOUD_PASSWORD`: Test user password (default: `testpass`)
+- `NEXTCLOUD_PASSWORD`: Test user password (default: `TestPassword123!`)
 
 ## Disabling Nextcloud Tests
 

--- a/tests/docker-test-servers/nextcloud/docker-compose.yml
+++ b/tests/docker-test-servers/nextcloud/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  nextcloud:
+    image: nextcloud:latest
+    container_name: nextcloud-test
+    ports:
+      - "8801:80"
+    environment:
+      - SQLITE_DATABASE=nextcloud
+      - NEXTCLOUD_ADMIN_USER=admin
+      - NEXTCLOUD_ADMIN_PASSWORD=admin
+      - NEXTCLOUD_TRUSTED_DOMAINS=localhost
+    volumes:
+      - nextcloud_data:/var/www/html
+
+volumes:
+  nextcloud_data:

--- a/tests/docker-test-servers/nextcloud/setup_nextcloud.sh
+++ b/tests/docker-test-servers/nextcloud/setup_nextcloud.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Setup script for Nextcloud test server
+# This script configures Nextcloud and creates a test user
+
+set -e
+
+CONTAINER_NAME="nextcloud-test"
+TEST_USER="testuser"
+TEST_PASSWORD="testpass"
+
+echo "Waiting for Nextcloud to be ready..."
+max_attempts=60
+for i in $(seq 1 $max_attempts); do
+    if docker exec $CONTAINER_NAME php occ status 2>/dev/null | grep -q "installed: true"; then
+        echo "✓ Nextcloud is ready"
+        break
+    fi
+    if [ $i -eq $max_attempts ]; then
+        echo "✗ Nextcloud did not become ready in time"
+        exit 1
+    fi
+    echo -n "."
+    sleep 2
+done
+
+echo ""
+echo "Creating test user..."
+# Create test user (ignore error if already exists)
+docker exec $CONTAINER_NAME php occ user:add --password-from-env --display-name="Test User" $TEST_USER <<< "$TEST_PASSWORD" 2>/dev/null || echo "User may already exist"
+
+echo "Enabling calendar app..."
+docker exec $CONTAINER_NAME php occ app:enable calendar || true
+
+echo "Enabling contacts app..."
+docker exec $CONTAINER_NAME php occ app:enable contacts || true
+
+echo ""
+echo "✓ Nextcloud setup complete!"
+echo ""
+echo "Credentials:"
+echo "  Admin: admin / admin"
+echo "  Test user: $TEST_USER / $TEST_PASSWORD"
+echo "  CalDAV URL: http://localhost:8801/remote.php/dav"
+echo ""

--- a/tests/docker-test-servers/nextcloud/start.sh
+++ b/tests/docker-test-servers/nextcloud/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Quick start script for Nextcloud test server
+#
+# Usage: ./start.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Starting Nextcloud CalDAV server..."
+docker-compose up -d
+
+echo ""
+echo "Waiting for Nextcloud to initialize (this may take a minute)..."
+./setup_nextcloud.sh
+
+echo "To stop Nextcloud: ./stop.sh"
+echo "To view logs: docker-compose logs -f nextcloud"

--- a/tests/docker-test-servers/nextcloud/stop.sh
+++ b/tests/docker-test-servers/nextcloud/stop.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Stop script for Nextcloud test server
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Stopping Nextcloud (data will be preserved in volume)..."
+docker-compose stop
+
+echo "✓ Nextcloud stopped"
+echo ""
+echo "To remove all data: docker-compose down -v"


### PR DESCRIPTION
Introduces a nextcloud docker container in the test framework, following the same pattern as the Baikal testing framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)