### PR TITLE
Transparent fallback for servers not supporting sync tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ This project should adhere to [Semantic Versioning](https://semver.org/spec/v2.0
 * New dependency on the python-dns package, for RFC6764 discovery.  As far as I understand the SemVer standard, new dependencies can be added without increasing the major version number - but for some scenarios where it's hard to add new dependencies, this may be a breaking change.  This is a well-known package, so the security impact should be low.  This library is only used when doing such a recovery.  If anyone minds this dependency, I can change the project so this becomes an optional dependency.
 * Some code has been split out into a new package - `icalendar-searcher`. so this may also break if you manage the dependencies manually.  This library was written by me, so the security impact is low.
 * Not really breaking as such, but the test suite may now take a lot of time to run.  See the "Test Suite" section below.
+* When using the sync-token API now on servers not supporting sync-token, the full calendar will be fetched on every sync.  The change is intended to be un-breaking, but for people having very big calendars and syncing them to a mobile device with limited memory, bandwidth, CPU and battery, this change may be painful.
 
 ### Changed
 
+* Transparent handling of calendar servers not supporting sync-tokens.  The API will yield the same result, albeit with more bandwidth and memory consumption.
 * I'm still working on "compatibility hints".  Unfortunately, documentation is still missing.  The gist of it:
   * Use `features: posteo` instead of `url: https://posteo.de:8443/` in the connection configuration.
   * Use `features: nextcloud` and `url: my.nextcloud.provider.eu` instead of `url: https://my.nextcloud.provider.eu/remote.php/dav`

--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -1084,4 +1084,11 @@ gmx = {
     ]
 }
 
+sogo = {
+    "search.time-range.accurate": {
+        "support": "unsupported",
+        "description": "SOGo returns events/todos that fall outside the requested time range. For recurring events, it may return recurrences that start after the search interval ends, or events with no recurrences in the requested range at all."
+    }
+}
+
 # fmt: on

--- a/caldav/search.py
+++ b/caldav/search.py
@@ -281,7 +281,10 @@ class CalDAVSearcher(Searcher):
         things = [f"_property_{thing}" for thing in things]
         if (
             not calendar.client.features.is_supported("search.text.category")
-            and ("categories" in self._property_filters or "category" in self._property_filters)
+            and (
+                "categories" in self._property_filters
+                or "category" in self._property_filters
+            )
             and post_filter is not False
         ):
             replacements = {}

--- a/caldav/search.py
+++ b/caldav/search.py
@@ -281,13 +281,14 @@ class CalDAVSearcher(Searcher):
         things = [f"_property_{thing}" for thing in things]
         if (
             not calendar.client.features.is_supported("search.text.category")
-            and "categories" in self._property_filters
+            and ("categories" in self._property_filters or "category" in self._property_filters)
             and post_filter is not False
         ):
             replacements = {}
             for thing in things:
                 replacements[thing] = getattr(self, thing).copy()
-                replacements[thing].pop("categories")
+                replacements[thing].pop("categories", None)
+                replacements[thing].pop("category", None)
             clone = replace(self, **replacements)
             objects = clone.search(calendar, server_expand, split_expanded, props, xml)
             return self.filter(objects, post_filter, split_expanded, server_expand)

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1802,6 +1802,7 @@ END:VCALENDAR
 
         some_events = c.search(comp_class=Event, summary="Bastille Day Party")
         assert len(some_events) == 1
+
         some_events = c.search(comp_class=Event, summary="Bastille Day")
         ## fragile substring searches => anything could happen
         if self.is_supported("search.text.substring", str) == "fragile":
@@ -1814,6 +1815,12 @@ END:VCALENDAR
             assert len(some_events) == 0
         else:
             assert len(some_events) == 2
+
+        ## Explicit substring filter should always work
+        searcher = CalDAVSearcher(event=True)
+        searcher.add_property_filter("summary", "Bastille Day", "contains")
+        some_events=searcher.search(c)
+        assert len(some_events) == 2
 
         ## An explicit substring search should always do a substring search
         searcher = CalDAVSearcher(event=True)

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1819,7 +1819,7 @@ END:VCALENDAR
         ## Explicit substring filter should always work
         searcher = CalDAVSearcher(event=True)
         searcher.add_property_filter("summary", "Bastille Day", "contains")
-        some_events=searcher.search(c)
+        some_events = searcher.search(c)
         assert len(some_events) == 2
 
         ## An explicit substring search should always do a substring search


### PR DESCRIPTION
There are several servers that don't support sync-tokens, and I left a note in https://github.com/python-caldav/caldav/issues/461 that it would be nice to implement transparent fallback of this.   Bandwidth is cheap nowadays, and few calendar owner have megabyte-sized calendars (that said, our work calendar does not support sync-tokens and I do remember my phone going hot and running out of battery fast after I installed caldav syncing on it a while ago).

A commit fixing some test code and fixing a minor bugfix for categories sneaked in on his pull request.