### PR TITLE
Fix duplicate parameter bug in search() recursive call

### DIFF
--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -976,7 +976,6 @@ class Calendar(DAVObject):
             ## those arguments:
             kwargs2 = {
                 "include_completed": include_completed,
-                "sort_reverse": sort_reverse,
                 "expand": expand,
                 "server_expand": server_expand,
                 "split_expanded": split_expanded,
@@ -1012,7 +1011,7 @@ class Calendar(DAVObject):
                     return self.search(
                         sort_keys=sort_keys,
                         sort_reverse=sort_reverse,
-                        *kwargs2,
+                        **kwargs2,
                         **kwargs,
                     )
                 raise


### PR DESCRIPTION
This pull request is based on the v2.1.2-release and could possibly go in as a 2.1.3-release.

Fixed issue https://github.com/python-caldav/caldav/issues/587 where the recursive search() call had multiple bugs:
1. Used invalid syntax *kwargs2 instead of **kwargs2 to unpack dict
2. Passed sort_reverse both explicitly and in kwargs2 dict

This caused TypeError: Calendar.search() got multiple values for argument 'sort_keys' when the backward compatibility fallback code path was triggered (when a server returns an error on searches without explicit comp_class).

The bug was introduced in commit 507b080d during compatibility hints refactoring and wasn't caught earlier because this code path is only executed for specific server error conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)