### PR TITLE
Add a DTSTAMP in events that are missing them.

### DIFF
--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -874,11 +874,9 @@ synology = {
     'search.time-range.alarm': False,
     'sync-token': 'fragile',
     'delete-calendar': False,
-    'delete-calendar.free-namespace': False,
     'search.comp-type-optional': 'fragile',
     "search.recurrences.expanded.exception": False,
-    'test-calendar': {'cleanup-regime': 'wipe-calendar'},
-    'old_flags': ['vtodo_datesearch_nodtstart_task_is_skipped'],
+     'old_flags': ['vtodo_datesearch_nodtstart_task_is_skipped'],
 }
 
 baikal =  { ## version 0.10.1
@@ -1034,12 +1032,6 @@ sogo = {
 #    'text_search_is_exact_match_sometimes',
 #    'rrule_takes_no_count',
 #    'isnotdefined_not_working',
-#]
-
-#synology = [
-#    "fragile_sync_tokens",
-#    "vtodo_datesearch_notime_task_is_skipped",
-#    "no_recurring_todo",
 #]
 
 robur = {

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -58,6 +58,18 @@ def fix(event):
     and duration set - which is forbidden according to the RFC.  We
     should probably verify that the data is consistent.  As for now,
     we'll just drop DURATION or DTEND (whatever comes last).
+
+    6) On FOSSDEM I was presented with icalendar data missing the
+    DTSTAMP field.  This is mandatory according to the RFC.
+
+    All logic here is done with on the ical string, and not on
+    icalendar objects.  There are two reasons for it, originally
+    optimization (not having to parse the icalendar data and create an
+    object, if it's to be tossed away again shortly afterwards), but
+    also because broken icalendar data may cause the instantiation of
+    an icalendar object to break.
+
+    TODO: this should probably be moved out from the library.
     """
     event = to_normal_str(event)
     if not event.endswith("\n"):
@@ -76,6 +88,13 @@ def fix(event):
 
     ## 4) trailing whitespace probably never makes sense
     fixed = re.sub(" *$", "", fixed)
+
+    ## 6) add DTSTAMP if not given
+    ## (corner case that DTSTAMP is given in one but not all the recurrences is ignored)
+    if not '\nDTSTAMP:' in fixed:
+        assert ('\nEND' in fixed)
+        dtstamp=datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+        fixed = re.sub('(\nEND:(VTODO|VEVENT|VJOURNAL))', f'\nDTSTAMP:{dtstamp}\\1', fixed)
 
     ## 3 fix duplicated DTSTAMP ... and ...
     ## 5 prepare to remove DURATION or DTEND/DUE if both DURATION and

--- a/caldav/lib/vcal.py
+++ b/caldav/lib/vcal.py
@@ -91,10 +91,14 @@ def fix(event):
 
     ## 6) add DTSTAMP if not given
     ## (corner case that DTSTAMP is given in one but not all the recurrences is ignored)
-    if not '\nDTSTAMP:' in fixed:
-        assert ('\nEND' in fixed)
-        dtstamp=datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-        fixed = re.sub('(\nEND:(VTODO|VEVENT|VJOURNAL))', f'\nDTSTAMP:{dtstamp}\\1', fixed)
+    if not "\nDTSTAMP:" in fixed:
+        assert "\nEND" in fixed
+        dtstamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime(
+            "%Y%m%dT%H%M%SZ"
+        )
+        fixed = re.sub(
+            "(\nEND:(VTODO|VEVENT|VJOURNAL))", f"\nDTSTAMP:{dtstamp}\\1", fixed
+        )
 
     ## 3 fix duplicated DTSTAMP ... and ...
     ## 5 prepare to remove DURATION or DTEND/DUE if both DURATION and

--- a/tests/test_vcal.py
+++ b/tests/test_vcal.py
@@ -335,7 +335,11 @@ END:VJOURNAL
 END:VCALENDAR"""
 
         # Test each component type
-        for ical in [double_event_without_dtstamp, todo_without_dtstamp, journal_without_dtstamp]:
+        for ical in [
+            double_event_without_dtstamp,
+            todo_without_dtstamp,
+            journal_without_dtstamp,
+        ]:
             # Verify the original doesn't have DTSTAMP
             assert "DTSTAMP:" not in ical
 
@@ -347,12 +351,14 @@ END:VCALENDAR"""
 
             # Verify it matches the expected format (YYYYMMDDTHHMMSSZ)
             dtstamp_match = re.search(r"DTSTAMP:(\d{8}T\d{6}Z)", fixed)
-            assert dtstamp_match is not None, f"DTSTAMP should be in correct format in:\n{fixed}"
+            assert (
+                dtstamp_match is not None
+            ), f"DTSTAMP should be in correct format in:\n{fixed}"
 
-            if ical.count('BEGIN:VEVENT') == 2:
-                assert fixed.count('DTSTAMP:') == 2
+            if ical.count("BEGIN:VEVENT") == 2:
+                assert fixed.count("DTSTAMP:") == 2
             else:
-                assert fixed.count('DTSTAMP:') == 1
+                assert fixed.count("DTSTAMP:") == 1
 
             # Verify the fixed ical is valid
             self.verifyICal(fixed)


### PR DESCRIPTION
Fixes #504 

Test case partly made by Claude.  I'd say I did it the right way, first asking Claude to make a (broken) test, adding some corner case to it, then implementing the feature and then debugging and fixing both the logic and test until it passed.  Asking Claude to make the test code *after* the logic has been fixed sometimes causes bugs in the code to be mirrored in the test.

This fix may not cover all possible corner cases, but I consider it good enough.