### PR TITLE
Update examples to use get_davclient() instead of DAVClient()

### DIFF
--- a/examples/example_rfc6764_usage.py
+++ b/examples/example_rfc6764_usage.py
@@ -4,14 +4,14 @@ Example usage of RFC6764 service discovery in python-caldav
 
 This script demonstrates how the RFC6764 integration works.
 """
-from caldav import DAVClient
+from caldav.davclient import get_davclient
 
 # Example 1: Automatic RFC6764 discovery with email address
 # Username is automatically extracted from the email address
 print("Example 1: Using email address (username auto-extracted)")
 print("-" * 70)
 try:
-    client = DAVClient(
+    client = get_davclient(
         url="user@example.com",  # Domain will be extracted, username preserved
         password="password",  # Username extracted from email, just provide password
     )
@@ -27,7 +27,7 @@ print("\n")
 print("Example 2: Using username for discovery (no URL parameter)")
 print("-" * 70)
 try:
-    client = DAVClient(
+    client = get_davclient(
         username="user@example.com",  # URL discovered from username
         password="password",
     )
@@ -42,7 +42,9 @@ print("\n")
 print("Example 3: Using bare domain (RFC6764 discovery enabled by default)")
 print("-" * 70)
 try:
-    client = DAVClient(url="calendar.example.com", username="user", password="password")
+    client = get_davclient(
+        url="calendar.example.com", username="user", password="password"
+    )
     print(f"Client URL after discovery: {client.url}")
 except Exception as e:
     print(f"Discovery failed (expected for example.com): {e}")
@@ -53,7 +55,7 @@ print("\n")
 print("Example 4: Disable RFC6764 discovery (use feature hints instead)")
 print("-" * 70)
 try:
-    client = DAVClient(
+    client = get_davclient(
         url="calendar.example.com",
         username="user",
         password="password",
@@ -69,7 +71,7 @@ print("\n")
 # Example 5: Full URL bypasses discovery
 print("Example 5: Full URL (RFC6764 discovery automatically skipped)")
 print("-" * 70)
-client = DAVClient(
+client = get_davclient(
     url="https://caldav.example.com/dav/", username="user", password="password"
 )
 print(f"Client URL (no discovery needed): {client.url}")
@@ -79,7 +81,7 @@ print("\n")
 # Example 6: Using feature hints with NextCloud
 print("Example 6: Using feature hints (NextCloud)")
 print("-" * 70)
-client = DAVClient(
+client = get_davclient(
     url="nextcloud.example.com",
     username="user",
     password="password",

--- a/examples/google-django.py
+++ b/examples/google-django.py
@@ -15,7 +15,7 @@ from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.models import SocialToken
 from google.oauth2.credentials import Credentials
 
-from caldav import DAVClient
+from caldav.davclient import get_davclient
 from caldav.requests import HTTPBearerAuth
 
 
@@ -45,7 +45,7 @@ def sync_calendar(user, calendar_id):
     credentials = get_google_credentials(user)
 
     # Set up CalDAV client with OAuth token
-    client = DAVClient(
+    client = get_davclient(
         url=f"https://apidata.googleusercontent.com/caldav/v2/{calendar_id}/events",
         auth=HTTPBearerAuth(credentials.token),
     )

--- a/examples/google-flask.py
+++ b/examples/google-flask.py
@@ -12,7 +12,7 @@ from flask import jsonify
 from flask import Response
 from google.oauth2.credentials import Credentials
 
-from caldav import DAVClient
+from caldav.davclient import get_davclient
 from caldav.requests import HTTPBearerAuth
 
 
@@ -93,7 +93,7 @@ def serve_calendar_ics(calendar_name):
         calendar_url = CALDAV_URL_TEMPLATE.format(calendar_id=calendar_id)
 
         # connect to the calendar using CalDAV
-        client = DAVClient(url=calendar_url, auth=HTTPBearerAuth(access_token))
+        client = get_davclient(url=calendar_url, auth=HTTPBearerAuth(access_token))
         principal = client.principal()
         calendars = principal.calendars()
 

--- a/examples/google-service-account.py
+++ b/examples/google-service-account.py
@@ -10,7 +10,7 @@ from google.oauth2 import service_account
 from google_auth_oauthlib.flow import InstalledAppFlow
 from requests.auth import AuthBase
 
-import caldav
+from caldav.davclient import get_davclient
 
 
 SERVICE_ACCOUNT_FILE = "service.json"
@@ -35,7 +35,7 @@ creds.refresh(Request())
 calid = "{ID}@group.calendar.google.com"
 url = "https://apidata.googleusercontent.com/caldav/v2/" + calid + "/events"
 
-client = caldav.DAVClient(url, auth=OAuth(creds))
+client = get_davclient(url, auth=OAuth(creds))
 
 for calendar in client.principal().calendars():
     events = calendar.events()

--- a/examples/scheduling_examples.py
+++ b/examples/scheduling_examples.py
@@ -11,8 +11,8 @@ from datetime import timezone
 from icalendar import Calendar
 from icalendar import Event
 
-from caldav import DAVClient
 from caldav import error
+from caldav.davclient import get_davclient
 
 
 ###############
@@ -34,9 +34,9 @@ class TestUser:
             conndata = rfc6638_users[i - 1].copy()
             if "incompatibilities" in conndata:
                 conndata.pop("incompatibilities")
-            self.client = DAVClient(**conndata)
+            self.client = get_davclient(**conndata)
         else:
-            self.client = DAVClient(
+            self.client = get_davclient(
                 username="testaccount%i" % i,
                 password="hunter2",
                 url="http://davical.bekkenstenveien53c.oslo.no/caldav.php/",


### PR DESCRIPTION
Changed 5 example files to use the recommended get_davclient() factory function:
- examples/scheduling_examples.py
- examples/google-flask.py
- examples/google-django.py
- examples/google-service-account.py
- examples/example_rfc6764_usage.py

This aligns examples with the official documentation which already
recommends get_davclient() throughout.
