### PR TITLE
Deprecate DAVObject.name in favor of get_display_name()

### DIFF
--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -599,12 +599,13 @@ class Calendar(DAVObject):
             client: A DAVClient instance
             url: The url for this calendar. May be a full URL or a relative URL.
             parent: The parent object (typically a CalendarSet or Principal)
-            name: The display name for the calendar
+            name: The display name for the calendar (stored in props cache)
             id: The calendar id (used when creating new calendars)
             props: A dict with known properties for this calendar
         """
-        super().__init__(client=client, url=url, parent=parent, id=id, props=props, **extra)
-        self.name = name
+        super().__init__(
+            client=client, url=url, parent=parent, id=id, props=props, name=name, **extra
+        )
 
     def _create(
         self, name=None, id=None, supported_calendar_component_set=None, method=None
@@ -986,14 +987,18 @@ class Calendar(DAVObject):
             return self._async_save(method)
 
         if self.url is None:
-            self._create(id=self.id, name=self.name, method=method, **self.extra_init_options)
+            # Get display name from props cache
+            display_name = self.props.get("{DAV:}displayname")
+            self._create(id=self.id, name=display_name, method=method, **self.extra_init_options)
         return self
 
     async def _async_save(self, method=None):
         """Async implementation of save."""
         if self.url is None:
+            # Get display name from props cache
+            display_name = self.props.get("{DAV:}displayname")
             await self._async_create(
-                name=self.name, id=self.id, method=method, **self.extra_init_options
+                name=display_name, id=self.id, method=method, **self.extra_init_options
             )
         return self
 


### PR DESCRIPTION
- `DAVObject.__init__` now accepts `name` parameter, stores in props cache as `{DAV:}displayname` (no deprecation warning on construction)
- `DAVObject.name `is now a property that calls `get_display_name()` and emits `DeprecationWarning` when accessed
- `Calendar.__init__` passes name to parent (stored in props cache)
- `Calendar.save()` uses props cache directly instead of `self.name`

Migration path:
- Old: `calendar.name` → New: `calendar.get_display_name()`
- Old: `Calendar(name="foo")` → Still works, stores in props cache

Closes #128