### PR TITLE
More async integration tests

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,10 +1,15 @@
 # Example domains that don't resolve
 https?://your\.server\.example\.com/.*
-https?://.*\.example\.com/.*
+https?://.*\.example\.com(:\d+)?(/.*)?$
+https?://domain/.*
 
 # Localhost URLs for test servers (not accessible in CI)
 http://localhost:\d+/.*
 http://localhost/.*
+http://.*@localhost:\d+/.*
+
+# Internal Docker hostnames (only reachable inside compose network)
+http://oxhost2:\d+/.*
 
 # CalDAV endpoints that require authentication (401/403 expected)
 https://caldav\.fastmail\.com/.*
@@ -24,8 +29,21 @@ http://nextcloud.org/ns
 http://owncloud.org/ns
 
 
+# Google API endpoints (require auth — 401/404/405 expected)
+https://apidata\.googleusercontent\.com/.*
+https://oauth2\.googleapis\.com/.*
+
+# Personal/demo test server (may be down)
+https?://davical\.bekkenstenveien53c\.oslo\.no/.*
+
+# Dead or broken links we can't fix
+http://fsf\.org/.*
+http://oxpedia\.org/.*
+http://httpd\.apache\.org/.*
+# GitHub URL template in sphinx conf (contains encoded braces, always 404)
+https://github\.com/python-caldav/caldav/blob/master/%7B.*
+
 # Other junk that was never meant to be followed
-# lychee converts unknown schemes to file:// URLs before matching ignore patterns
 file://.*/scheme:.*
 /17149682/.*
 http://x/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         stages: [commit-msg]
 
   - repo: https://github.com/lycheeverse/lychee
-    rev: lychee-v0.22.0
+    rev: lychee-v0.24.1
     hooks:
       - id: lychee
         args: ["--no-progress", "--timeout", "10", "--exclude-path", ".lycheeignore", "--max-cache-age=30d", "--cache"]

--- a/caldav/async_davclient.py
+++ b/caldav/async_davclient.py
@@ -124,7 +124,7 @@ class AsyncDAVClient(BaseDAVClient):
 
         Args:
             url: CalDAV server URL, domain, or email address.
-            proxy: Proxy server (scheme://hostname:port).
+            proxy: Proxy server (e.g. http://proxy.example.com:8080).
             username: Username for authentication.
             password: Password for authentication.
             auth: Custom auth object (httpx.Auth or niquests AuthBase).

--- a/caldav/async_davclient.py
+++ b/caldav/async_davclient.py
@@ -835,9 +835,9 @@ class AsyncDAVClient(BaseDAVClient):
             if _USE_HTTPX:
                 self.auth = httpx.DigestAuth(self.username, self.password)
             else:
-                from niquests.auth import HTTPDigestAuth
+                from niquests.auth import AsyncHTTPDigestAuth
 
-                self.auth = HTTPDigestAuth(self.username, self.password)
+                self.auth = AsyncHTTPDigestAuth(self.username, self.password)
         elif auth_type == "basic":
             if _USE_HTTPX:
                 self.auth = httpx.BasicAuth(self.username, self.password)

--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -1071,6 +1071,7 @@ class CalendarObjectResource(DAVObject):
     def _post_load_by_multiget(self, items):
         if not items:
             raise error.NotFoundError(self.url)
+        items = iter(items)
         url_data = next(items, None)
         if url_data is None:
             ## We shouldn't come here.  Something is wrong.
@@ -1147,7 +1148,10 @@ class CalendarObjectResource(DAVObject):
 
     async def _async_put(self, headers, retry_on_failure=True):
         r = await self.client.put(str(self.url), str(self.data), headers | ICALH)
-        return self._post_put(r, retry_on_failure)
+        result = self._post_put(r, retry_on_failure)
+        if result is not None:
+            # _post_put returned a retry coroutine (self._put(False) for async client)
+            await result
 
     def _post_put(self, r, retry_on_failure):
         if r.status == 412:

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -723,7 +723,14 @@ class Calendar(DAVObject):
 
         prop = dav.Prop()
         display_name = None
-        if name:
+        # Some servers (e.g. Zimbra) use the DisplayName from the MKCALENDAR body
+        # as the calendar URL, ignoring the actual request path.  When the server
+        # does not support setting a separate display name, omit it from the body so
+        # the request URL path is used as the calendar identifier.
+        supports_displayname = not self.client or self.client.features.is_supported(
+            "create-calendar.set-displayname"
+        )
+        if name and supports_displayname:
             display_name = dav.DisplayName(name)
             prop += [display_name]
         if supported_calendar_component_set:
@@ -747,7 +754,7 @@ class Calendar(DAVObject):
         # on setting the DisplayName on calendar creation
         # (DAViCal, Zimbra, ...).  Doing an attempt on explicitly setting the
         # display name using PROPPATCH.
-        if name:
+        if display_name:
             try:
                 self.set_properties([display_name])
             except Exception:
@@ -766,7 +773,7 @@ class Calendar(DAVObject):
         await self._query(root=mkcol, query_method=method, url=path, expected_return_value=201)
 
         # COMPATIBILITY ISSUE - try to set display name explicitly
-        if name:
+        if display_name:
             try:
                 await self.set_properties([display_name])
             except Exception:
@@ -1080,6 +1087,7 @@ class Calendar(DAVObject):
         """
         get multiple events' data.
         TODO: Does it overlap the _request_report_build_resultlist method
+        ## WARNING: async logic is duplicated in _async_multiget — mirror any changes there
         """
         if self.url is None:
             raise ValueError("Unexpected value None for self.url")
@@ -1098,28 +1106,33 @@ class Calendar(DAVObject):
         for r in results:
             yield (r, results[r][cdav.CalendarData.tag])
 
-    ## Replace the last lines with
+    def _post_multiget(self, results: Iterable[tuple[str, str]]) -> list[_CC]:
+        """Post-processing shared by multiget and _async_multiget_objects."""
+        return [
+            self._calendar_comp_class_by_data(data)(
+                self.client,
+                # Quote path to handle servers returning unencoded spaces (e.g., Zimbra)
+                url=self.url.join(quote(unquote(str(url)), safe="/:@")),
+                data=data,
+                parent=self,
+            )
+            for url, data in results
+        ]
+
     def multiget(self, event_urls: Iterable[URL], raise_notfound: bool = False) -> Iterable[_CC]:
         """
         get multiple events' data
         TODO: Does it overlap the _request_report_build_resultlist method?
         @author mtorange@gmail.com (refactored by Tobias)
         """
-        results = self._multiget(event_urls, raise_notfound=raise_notfound)
-        for url, data in results:
-            # Quote path to handle servers returning unencoded spaces (e.g., Zimbra)
-            quoted_url = quote(unquote(str(url)), safe="/:@")
-            yield self._calendar_comp_class_by_data(data)(
-                self.client,
-                url=self.url.join(quoted_url),
-                data=data,
-                parent=self,
-            )
+        if self.is_async_client:
+            return self._async_multiget_objects(event_urls, raise_notfound=raise_notfound)
+        return self._post_multiget(self._multiget(event_urls, raise_notfound=raise_notfound))
 
     async def _async_multiget(
         self, event_urls: Iterable[URL], raise_notfound: bool = False
     ) -> list[tuple[str, str]]:
-        """Async version of _multiget — returns a list of (url, data) tuples."""
+        ## WARNING: sync logic is duplicated in _multiget — mirror any changes there
         if self.url is None:
             raise ValueError("Unexpected value None for self.url")
 
@@ -1134,12 +1147,20 @@ class Calendar(DAVObject):
                     raise error.NotFoundError(f"Status {status} in {href}")
         return [(r, results[r][cdav.CalendarData.tag]) for r in results]
 
+    async def _async_multiget_objects(
+        self, event_urls: Iterable[URL], raise_notfound: bool = False
+    ) -> list[_CC]:
+        """Async version of multiget."""
+        return self._post_multiget(
+            await self._async_multiget(event_urls, raise_notfound=raise_notfound)
+        )
+
     def calendar_multiget(self, *largs, **kwargs):
         """
         get multiple events' data
         @author mtorange@gmail.com
         (refactored by Tobias)
-        This is for backward compatibility.  It may be removed in 3.0 or later release.
+        This is for backward compatibility.  It may be removed in a later release.
         """
         return list(self.multiget(*largs, **kwargs))
 
@@ -1605,7 +1626,12 @@ class Calendar(DAVObject):
     ) -> "Event":
         """Async helper for get_object_by_uid()."""
         items_found = await self.search(
-            uid=uid, comp_class=comp_class, xml=comp_filter, post_filter=True, _hacks="insist"
+            uid=uid,
+            comp_class=comp_class,
+            xml=comp_filter,
+            post_filter=True,
+            _hacks="insist",
+            include_completed=True,
         )
         items_found = [o for o in items_found if o.id == uid]
 

--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -77,6 +77,9 @@ class FeatureSet:
                 ## TODO: in the future, templates for the principal URL, calendar URLs etc may also be added.
             }
         },
+        "url": {
+            "type": "client-hints",
+        },
         "get-current-user-principal": {
             "description": "Support for RFC5397, current principal extension.  Most CalDAV servers have this, but it is an extension to the DAV standard.  Possibly observed missing on mail.ru, DavMail gateway and it is possible to configure the support in some sabre-based servers",
             "links": ["https://datatracker.ietf.org/doc/html/rfc5397"],
@@ -176,6 +179,10 @@ class FeatureSet:
             "description": "The server preserves RELATED-TO properties (RFC5545 section 3.8.4.5) when saving and loading calendar objects. When 'unsupported', the server may typically silently strip all RELATED-TO lines",
             "default": {"support": "full"},
             "links": ["https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.4.5"],
+        },
+        "save-load.mutable": {
+            "description": "A saved calendar object resource can be modified and PUT back to the server; the server accepts the update and returns the modified data on the next GET/REPORT. When 'unsupported', the server treats calendar objects as immutable after initial creation (e.g. Google Calendar's legacy CalDAV API). Replaces the old 'no_overwrite' compatibility flag.",
+            "default": {"support": "full"},
         },
         "search": {
             "description": "calendar MUST support searching for objects using the REPORT method, as specified in RFC4791, section 7",
@@ -855,9 +862,6 @@ incompatibility_description = {
     'vtodo-cannot-be-uncompleted':
         """If a VTODO object has been set with STATUS:COMPLETE, it's not possible to delete the COMPLTEDED attribute and change back to STATUS:IN-ACTION""",
 
-    'unique_calendar_ids':
-        """For every test, generate a new and unique calendar id""",
-
     'sticky_events':
         """Events should be deleted before the calendar is deleted, """
         """and/or deleting a calendar may not have immediate effect""",
@@ -927,7 +931,7 @@ radicale = {
     "search.text.case-sensitive": {"support": "unsupported"},
     "search.recurrences.includes-implicit.todo.pending": {"support": "fragile", "behaviour": "inconsistent results between runs"},
     "search.recurrences.expanded.todo": {"support": "unsupported"},
-    "search.recurrences.expanded.exception": {"support": "unsupported"},
+    "search.recurrences.expanded.exception": {"support": "full"},
     "principal-search": {"support": "unsupported"},
     ## this only applies for very simple installations
     "auto-connect.url": {"domain": "localhost", "scheme": "http", "basepath": "/"},
@@ -947,7 +951,6 @@ nextcloud = {
     ## I'm surprised, I'm quite sure this was reported ungraceful earlier.  Passed with caldav commit a98d50490b872e9b9d8e93e2e401c936ad193003, caldav server checker commit 3cae24cf99da1702b851b5a74a9b88c8e5317dad 2026-02-15.  The commit 3cae24cf99da1702b851b5a74a9b88c8e5317dad was however development done on the wrong branch and has been force-pushed awway.  It was again observed ungraceful at commits be26d42b1ca3ff3b4fd183761b4a9b024ce12b84 / 537a23b145487006bb987dee5ab9e00cdebb0492
     'search.comp-type.optional': {'support': 'ungraceful'},
     'search.recurrences.expanded.todo': {'support': 'unsupported'},
-    'search.recurrences.expanded.exception': {'support': 'unsupported'}, ## TODO: verify
     "search.recurrences.includes-implicit.infinite-scope": False,
     'delete-calendar': {
         'support': 'fragile',
@@ -961,7 +964,6 @@ nextcloud = {
     'principal-search.by-name.self': {'support': 'unsupported'},
     'principal-search': {'support': 'ungraceful'},
     'search.time-range.open.start.duration': 'broken',
-    #'old_flags': ['unique_calendar_ids'],
     ## I'm surprised, I'm quite sure this was passing earlier.  Caldav commit a98d50490b872e9b9d8e93e2e401c936ad193003, caldav server checker commit 3cae24cf99da1702b851b5a74a9b88c8e5317dad
     'search.combined-is-logical-and': False,
     ## Observed with Nextcloud 33: server delivers iTIP notification to the inbox AND
@@ -993,10 +995,11 @@ ecloud = nextcloud | {
 zimbra = {
     'auto-connect.url': {'basepath': '/dav/'},
     'delete-calendar': {'support': 'fragile', 'behaviour': 'may move to trashbin instead of deleting immediately'},
-    'save-load.get-by-url': {'support': 'fragile', 'behaviour': '404 most of the time - but sometimes 200.  Weird, should be investigated more'},
+    ## This is a zimbra bug when creating calendars with a display
+    ## name.  Now mitigated in the calendar creation code.
+    #'save-load.get-by-url': {'support': 'fragile', 'behaviour': '404 most of the time - but sometimes 200.  Weird, should be investigated more'},
     ## Zimbra treats same-UID events across calendars as aliases of the same event
     'save.duplicate-uid.cross-calendar': {'support': 'unsupported'},
-    'search.recurrences.expanded.exception': {'support': 'unsupported'}, ## TODO: verify
     'create-calendar.set-displayname': {'support': 'unsupported'},
     'save-load.todo.mixed-calendar': {'support': 'unsupported'},
     'save-load.todo.recurrences.count': {'support': 'unsupported'}, ## This is a new problem?
@@ -1060,7 +1063,6 @@ bedework = {
     "search.text": False, ## sometimes ungraceful
     "search.recurrences.includes-implicit": False,
     "sync-token": { "support": "fragile" },
-    "search.recurrences.expanded.exception": False,
     "search.recurrences.expanded.event": False,
     "search.recurrences.expanded.todo": False,
     'search.comp-type': {'support': 'broken', 'behaviour': 'Server returns everything when searching for events and nothing when searching for todos'},
@@ -1095,7 +1097,6 @@ synology = {
     'search.is-not-defined': {'support': 'fragile', 'behaviour': 'works for CLASS but not for CATEGORIES'},
     'search.text.case-sensitive': {'support': 'unsupported'},
     'search.time-range.alarm': {'support': 'unsupported'},
-    "search.recurrences.expanded.exception": False,
     'old_flags': ['vtodo_datesearch_nodtstart_task_is_skipped'],
     'test-calendar': {'cleanup-regime': 'wipe-calendar'},
     'scheduling.schedule-tag': False,
@@ -1109,7 +1110,6 @@ baikal =  { ## version 0.10.1
     "http.multiplexing": "fragile", ## ref https://github.com/python-caldav/caldav/issues/564
     'search.comp-type.optional': {'support': 'ungraceful'},
     'search.recurrences.expanded.todo': {'support': 'unsupported'},
-    'search.recurrences.expanded.exception': {'support': 'unsupported'},
     'search.recurrences.includes-implicit.todo': {'support': 'unsupported'},
     "search.recurrences.includes-implicit.infinite-scope": False,
     'save-load.journal.mixed-calendar': {'support': 'unsupported'},
@@ -1134,7 +1134,6 @@ baikal_old = baikal | {
 
 cyrus = {
     "search.comp-type.optional": {"support": "ungraceful"},
-    "search.recurrences.expanded.exception": {"support": "unsupported"},
     "search.recurrences.includes-implicit.infinite-scope": False,
     "search.time-range.alarm": {"support": "ungraceful"},
     'principal-search': {'support': 'ungraceful'},
@@ -1156,7 +1155,6 @@ cyrus = {
 
 ## See comments on https://github.com/python-caldav/caldav/issues/3
 #icloud = [
-#    'unique_calendar_ids',
 #    'duplicate_in_other_calendar_with_same_uid_breaks',
 #    'sticky_events',
 #    'no_journal', ## it threw a 500 internal server error!
@@ -1175,7 +1173,6 @@ davical = {
     # into their calendar.
     "scheduling.schedule-tag": False,
     "search.comp-type.optional": { "support": "fragile" },
-    "search.recurrences.expanded.exception": { "support": "unsupported" },
     "search.time-range.alarm": { "support": "unsupported" },
     'sync-token': {'support': 'fragile'},
     'principal-search': {'support': 'unsupported'},
@@ -1285,7 +1282,6 @@ robur = {
     "search.comp-type.optional": { "support": "ungraceful" },
     "search.recurrences.expanded.todo": { "support": "unsupported" },
     "search.recurrences.expanded.event": { "support": "fragile" },
-    "search.recurrences.expanded.exception": { "support": "unsupported" },
     'search.recurrences.includes-implicit.todo': {'support': 'unsupported'},
     'principal-search': {'support': 'ungraceful'},
     'freebusy-query': {'support': 'ungraceful'},
@@ -1327,7 +1323,6 @@ posteo = {
     ## foo ... "full" observed, 70938dc1cbb6a839978eee4315699746d38ee5f0/3cae24cf99da1702b851b5a74a9b88c8e5317dad, 2026-02-17
     #'search.time-range.todo.old-dates': {'support': 'unsupported'},
     'search.recurrences.expanded.todo': {'support': 'unsupported'},
-    'search.recurrences.expanded.exception': {'support': 'unsupported'},
     'search.recurrences.includes-implicit.todo': {'support': 'unsupported'},
     'search.combined-is-logical-and': {'support': 'unsupported'},
     'sync-token': {'support': 'ungraceful'},
@@ -1356,7 +1351,6 @@ davis = {
     # attendee inbox AND auto-schedules into their calendar.
     "scheduling.schedule-tag": False,
     "search.recurrences.expanded.todo": {"support": "unsupported"},
-    "search.recurrences.expanded.exception": {"support": "unsupported"},
     "search.recurrences.includes-implicit.todo": {"support": "unsupported"},
     "search.recurrences.includes-implicit.infinite-scope": False,
     "principal-search.by-name.self": {"support": "unsupported"},
@@ -1467,7 +1461,6 @@ purelymail = {
     'search.time-range.event': {'support': 'fragile'},
     ## was: ungraceful - observed unsupported 2026-02 (for .old-dates)
     'search.time-range.todo': {'support': 'fragile'},
-    'search.recurrences.expanded.exception': {'support': 'unsupported'},
     'principal-search': {'support': 'ungraceful'},
     'principal-search.by-name.self': {'support': 'ungraceful'},
     'principal-search.list-all': {'support': 'ungraceful'},

--- a/caldav/davclient.py
+++ b/caldav/davclient.py
@@ -198,11 +198,11 @@ class DAVClient(BaseDAVClient):
                - Full URL: `https://caldav.example.com/dav/`
                - Domain: `example.com` (will attempt RFC6764 discovery if enable_rfc6764=True)
                - Email: `user@example.com` (will attempt RFC6764 discovery if enable_rfc6764=True)
-               - URL with auth: `scheme://user:pass@hostname:port`
+               - URL with auth: `http://user:pass@proxy.example.com:8080`
                - Omit URL: Use `username='user@example.com'` for discovery
           username: Username for authentication. If url is omitted and username contains @,
                     RFC6764 discovery will be attempted using the username as email address.
-          proxy: A string defining a proxy server: `scheme://hostname:port`. Scheme defaults to http, port defaults to 8080.
+          proxy: A string defining a proxy server: `http://proxy.example.com:8080`. Scheme defaults to http, port defaults to 8080.
           auth: A niquests.auth.AuthBase or requests.auth.AuthBase object, may be passed instead of username/password.  username and password should be passed as arguments or in the URL
           timeout and ssl_verify_cert are passed to niquests.request.
           if auth_type is given, the auth-object will be auto-created. Auth_type can be ``bearer``, ``digest`` or ``basic``. Things are likely to work without ``auth_type`` set, but if nothing else the number of requests to the server will be reduced, and some servers may require this to squelch warnings of unexpected HTML delivered from the

--- a/caldav/search.py
+++ b/caldav/search.py
@@ -993,6 +993,10 @@ class CalDAVSearcher(Searcher):
         assert self.event is None and self.todo is None and self.journal is None
 
         for comp_class in (Event, Todo, Journal):
+            if not calendar.client.features.is_supported(
+                f"save-load.{comp_class.__name__.lower()}"
+            ):
+                continue
             clone = replace(self)
             clone.comp_class = comp_class
             results = await clone.async_search(

--- a/docs/source/v3-migration.rst
+++ b/docs/source/v3-migration.rst
@@ -38,11 +38,11 @@ replace it with:
     from caldav import Event, Todo, Calendar           # OK
 
 All public symbols that were in ``caldav.objects`` should remain available directly
-from the ``caldav`` namespace
+from the ``caldav`` namespace.  Exceptions may apply.
 
 Wildcard import into caldav.* removed
 -------------------------------------
-Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but there are no guarantees that all imports will continue working.  If you have any issues, see :doc:`contact`.
+Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  Imports should work, but corner cases may exists.  If you have any issues, see :doc:`contact`.
 
 Config-file parse errors now raise exceptions
 ---------------------------------------------
@@ -308,9 +308,7 @@ context-manager "borrow" methods that give exclusive, safe write access.
 
 While inside the ``with`` block, the borrowed representation is the
 single source of truth.  Attempting to borrow a *different*
-representation raises ``RuntimeError``.  This means the current
-pattern is not completely thread-safe as of v3.x - but an explicit
-error is often better than updates silently being dropped.
+representation raises ``RuntimeError``.
 
 **The data representation remains the same:**
 

--- a/docs/source/v3-migration.rst
+++ b/docs/source/v3-migration.rst
@@ -2,12 +2,10 @@
 Migrating from caldav 2.x to 3.x
 =========================================
 
-v3.0 is mostly backward-compatible with v2.x.  Existing code should
+v3.x is mostly backward-compatible with v2.x.  Existing code should
 generally continue to run.  New method names and usage patterns exists
 alongside the old ones.  The purpose of this document is to give a
-primer on the "best current usage practice" as of v3.0.  It may be
-needed to implement some of the changes below before using future
-major versions like v4 or v5.
+primer on the "best current usage practice" as of v3.x.
 
 .. contents:: Contents
    :local:
@@ -44,9 +42,7 @@ from the ``caldav`` namespace
 
 Wildcard import into caldav.* removed
 -------------------------------------
-Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but I cannot give any guarantees that YOUR imports will continue working.  If you have any issues, then reach out.
-
-..todo:: how to add a link from "reach out" to the contact page?
+Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but there are no guarantees that all imports will continue working.  If you have any issues, see :doc:`contact`.
 
 Config-file parse errors now raise exceptions
 ---------------------------------------------
@@ -247,7 +243,7 @@ Rationale: Those methods are also querying the server actively, and not just loo
 Accessing and editing calendar data
 =====================================
 
-This is the most significant new API in v3.0, addressing a long-standing
+This is the most significant new API in v3.x, addressing a long-standing
 ambiguity in how calendar object data was accessed and modified.
 
 The old ``vobject_instance``, ``icalendar_instance``, ``icalendar_component`` are now deprecated.
@@ -271,7 +267,7 @@ internal slot.  Accessing one representation could silently invalidate another:
 The 3.x Solution: read and edit methods
 -----------------------------------------
 
-v3.0 adds explicit read-only getters that always return **copies**, and
+v3.x adds explicit read-only getters that always return **copies**, and
 context-manager "borrow" methods that give exclusive, safe write access.
 
 **Read-only access** (safe at any time, returns a copy):
@@ -313,7 +309,7 @@ context-manager "borrow" methods that give exclusive, safe write access.
 While inside the ``with`` block, the borrowed representation is the
 single source of truth.  Attempting to borrow a *different*
 representation raises ``RuntimeError``.  This means the current
-pattern is not completely thread-safe as of v3.0 - but an explicit
+pattern is not completely thread-safe as of v3.x - but an explicit
 error is often better than updates silently being dropped.
 
 **The data representation remains the same:**
@@ -354,7 +350,7 @@ The interface for the string representation is still the same.  Strings are immu
      - Replace all data from a raw string
 
 
-New in v3.0
+New in v3.x
 ============
 
 Async client
@@ -486,10 +482,10 @@ If the server gives a `retry-after`-header on 429 or 530 it will be respected, o
 
 The total sleep period will never exceed 120, no matter if retry-after is given or not.
 
-Deprecated in v3.0 (will be removed in v4.0)
-=============================================
+Deprecated in v3.x
+==================
 
-The following emit ``DeprecationWarning``:
+The following emit ``DeprecationWarning`` and may be removed in v4.0:
 
 * ``calendar.date_search()`` — use ``calendar.search()``
 * ``client.principals()`` — use ``client.search_principals()``
@@ -498,7 +494,7 @@ The following emit ``DeprecationWarning``:
 * ``.instance`` property on calendar objects — use ``.vobject_instance``
 * ``response.find_objects_and_props()`` — use ``response.results``
 
-The following are deprecated but do **not yet** emit warnings:
+The following are deprecated, do **not yet** emit warnings and may be removed in v5.0:
 
 * All ``save_*`` methods → use ``add_*``
 * All ``*_by_uid()`` methods → use ``get_*_by_uid()``

--- a/examples/basic_usage_examples.py
+++ b/examples/basic_usage_examples.py
@@ -113,9 +113,6 @@ def find_delete_calendar_demo(my_principal, calendar_name):
 def add_stuff_to_calendar_demo(calendar):
     """
     This demo adds some stuff to the calendar
-
-    Unfortunately the arguments that it's possible to pass to save_* is poorly documented.
-    https://github.com/python-caldav/caldav/issues/253
     """
     ## Add an event with some certain attributes
     print("Saving an event")

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -17,6 +17,17 @@ import pytest_asyncio
 
 from caldav.compatibility_hints import FeatureSet
 
+from .test_caldav import (
+    ev1 as ev1_static,  # old-date (2006); distinct from ev1() near-future generator
+)
+from .test_caldav import ev2 as ev2_static  # same UID as ev1_static, one year later
+from .test_caldav import ev3 as ev3_static  # different UID (2021)
+from .test_caldav import evr as evr_static  # recurring annual event (1997)
+from .test_caldav import evr2 as evr2_static  # bi-weekly with exception (2024)
+from .test_caldav import journal as journal_static
+from .test_caldav import todo as todo_static  # avoids clash with local var in add_todo()
+from .test_caldav import todo2 as todo2_static  # avoids clash with todo2() generator
+from .test_caldav import todo3 as todo3_static
 from .test_servers import TestServer, get_available_servers
 
 
@@ -248,18 +259,21 @@ class AsyncFunctionalTestsBaseClass:
 
         For servers that don't support mixed calendars (like Zimbra), todos must
         be stored in a separate task list with supported_calendar_component_set=["VTODO"].
+
+        Uses the same stable cal_id ("pythoncaldav-test-tasks") as the sync test suite
+        so that both share state rather than accumulate duplicate-UID conflicts on
+        servers with cross-calendar UID uniqueness (e.g. OX).  Objects are wiped
+        before each test for isolation.
         """
         from caldav.aio import AsyncPrincipal
         from caldav.lib.error import AuthorizationError, NotFoundError
 
-        from .fixture_helpers import aget_or_create_test_calendar
+        from .fixture_helpers import aget_or_create_test_calendar, cleanup_calendar_objects
 
         # Check if server supports mixed calendars
         supports_mixed = True
         if hasattr(async_client, "features") and async_client.features:
             supports_mixed = async_client.features.is_supported("save-load.todo.mixed-calendar")
-
-        calendar_name = f"async-task-list-{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
 
         # Try to get principal for calendar operations
         principal = None
@@ -268,18 +282,31 @@ class AsyncFunctionalTestsBaseClass:
         except (NotFoundError, AuthorizationError):
             pass
 
-        # For servers without mixed calendar support, create a dedicated task list
+        # For servers without mixed calendar support, create a dedicated task list.
+        # Use the same stable cal_id as the sync test suite so servers with
+        # cross-calendar duplicate-UID detection (e.g. OX) don't reject objects
+        # that also exist in the sync test's calendar.
         component_set = ["VTODO"] if not supports_mixed else None
+        cal_id = "pythoncaldav-test-tasks" if not supports_mixed else "pythoncaldav-async-test"
+        supports_displayname = (
+            async_client.features.is_supported("create-calendar.set-displayname")
+            if hasattr(async_client, "features") and async_client.features
+            else True
+        )
+        calendar_name = cal_id if supports_displayname else None
 
         calendar, created = await aget_or_create_test_calendar(
             async_client,
             principal,
             calendar_name=calendar_name,
+            cal_id=cal_id,
             supported_calendar_component_set=component_set,
         )
 
         if calendar is None:
             pytest.skip("Could not create or find a task list for testing")
+
+        await cleanup_calendar_objects(calendar)
 
         yield calendar
 
@@ -289,6 +316,91 @@ class AsyncFunctionalTestsBaseClass:
                 await calendar.delete()
             except Exception:
                 pass
+
+    @pytest_asyncio.fixture
+    async def async_calendar2(self, async_client: Any) -> Any:
+        """Create a second test calendar for tests that need two distinct calendars."""
+        from caldav.aio import AsyncPrincipal
+        from caldav.lib.error import AuthorizationError, NotFoundError
+
+        from .fixture_helpers import aget_or_create_test_calendar
+
+        calendar_name = f"async-test2-{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+
+        principal = None
+        try:
+            principal = await AsyncPrincipal.create(async_client)
+        except (NotFoundError, AuthorizationError):
+            pass
+
+        calendar, created = await aget_or_create_test_calendar(
+            async_client, principal, calendar_name=calendar_name
+        )
+
+        if calendar is None:
+            pytest.skip("Could not create or find a second calendar for testing")
+
+        yield calendar
+
+        if created:
+            try:
+                await calendar.delete()
+            except Exception:
+                pass
+
+    @pytest_asyncio.fixture
+    async def async_journal_list(self, async_client: Any) -> Any:
+        """Create a VJOURNAL calendar for journal tests."""
+        from caldav.aio import AsyncPrincipal
+        from caldav.lib.error import AuthorizationError, NotFoundError
+
+        from .fixture_helpers import aget_or_create_test_calendar
+
+        calendar_name = f"async-journal-{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+
+        principal = None
+        try:
+            principal = await AsyncPrincipal.create(async_client)
+        except (NotFoundError, AuthorizationError):
+            pass
+
+        calendar, created = await aget_or_create_test_calendar(
+            async_client,
+            principal,
+            calendar_name=calendar_name,
+            supported_calendar_component_set=["VJOURNAL"],
+        )
+
+        if calendar is None:
+            pytest.skip("Could not create or find a journal list for testing")
+
+        yield calendar
+
+        if created:
+            try:
+                await calendar.delete()
+            except Exception:
+                pass
+
+    async def _make_async_client_with_params(self, **overrides: Any) -> Any:
+        """Build a fresh async client from this server's config with kwargs overridden.
+
+        Used by auth-error tests (wrong password, wrong auth type) that need a
+        client that is expected to fail to connect.
+        """
+        from caldav.aio import get_async_davclient
+
+        kwargs: dict[str, Any] = {
+            "url": self.server.url,
+            "username": self.server.username,
+            "password": self.server.password,
+            "features": self.server.features,
+            "probe": False,
+        }
+        if "ssl_verify_cert" in self.server.config:
+            kwargs["ssl_verify_cert"] = self.server.config["ssl_verify_cert"]
+        kwargs.update(overrides)
+        return await get_async_davclient(**kwargs)
 
     # ==================== Test Methods ====================
 
@@ -469,6 +581,189 @@ class AsyncFunctionalTestsBaseClass:
         assert str(org) == str(expected_vcal), (
             f"ORGANIZER {org!r} should match the principal's address {expected_vcal!r}"
         )
+
+    # ==================== Group A – Core CRUD ====================
+
+    @pytest.mark.asyncio
+    async def test_get_supported_components(self, async_calendar: Any) -> None:
+        """get_supported_components() must include VEVENT."""
+        components = await async_calendar.get_supported_components()
+        assert components
+        assert "VEVENT" in components
+
+    @pytest.mark.asyncio
+    async def test_lookup_event(self, async_calendar: Any) -> None:
+        """Add an event and look it up by URL, by UID, and via Event(url=…).load()."""
+        from caldav import Event
+        from caldav.lib import error
+
+        self.skip_unless_support("save-load.event")
+        c = async_calendar
+
+        # create the event
+        e1 = await c.add_event(ev1_static)
+        assert e1.url is not None
+
+        # Verify that we can look it up from calendar by url
+        e2 = await c.event_by_url(e1.url)
+        assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        assert e2.url == e1.url
+
+        # look up by UID
+        e3 = await c.get_event_by_uid("20010712T182145Z-123401@example.com")
+        assert str(e3.icalendar_component["uid"]) == "20010712T182145Z-123401@example.com"
+        assert e3.url == e1.url
+
+        # load directly from URL without going through the calendar object
+        e4 = Event(client=c.client, url=e1.url)
+        await e4.load()
+        assert str(e4.icalendar_component["uid"]) == "20010712T182145Z-123401@example.com"
+
+        with pytest.raises(error.NotFoundError):
+            await c.get_event_by_uid("nonexistent-uid-000")
+
+    @pytest.mark.asyncio
+    async def test_create_overwrite_delete_event(self, async_calendar: Any) -> None:
+        """no_create/no_overwrite flags, same-UID overwrite, and delete."""
+        from caldav.lib import error
+
+        self.skip_unless_support("save-load.event")
+        c = async_calendar
+
+        # attempting to update a non-existing event must raise ConsistencyError
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_create=True)
+
+        # no_create + no_overwrite is always an error
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_create=True, no_overwrite=True)
+
+        e1 = await c.add_event(ev1_static)
+        assert e1.url is not None
+
+        # same UID again → overwrite (unless server forbids it)
+        if not self.is_supported("save-load.mutable"):
+            e2 = await c.add_event(ev1_static)
+
+            # no_create on an existing event must succeed
+            e2 = await c.add_event(ev1_static, no_create=True)
+
+            # modify and save with no_create
+            e2.icalendar_component["summary"] = "Bastille Day Party!"
+            await e2.save(no_create=True)
+
+            e3 = await c.event_by_url(e1.url)
+            assert e3.icalendar_component["summary"] == "Bastille Day Party!"
+
+        # no_overwrite on an existing event must raise ConsistencyError
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_overwrite=True)
+
+        await e1.delete()
+
+        with pytest.raises(error.NotFoundError):
+            await c.event_by_url(e1.url)
+        with pytest.raises(error.NotFoundError):
+            await c.get_event_by_uid("20010712T182145Z-123401@example.com")
+
+    @pytest.mark.asyncio
+    async def test_object_by_uid(self, async_task_list: Any) -> None:
+        """Add a TODO with a known UID and retrieve it via get_object_by_uid()."""
+        from caldav.lib import error
+
+        c = async_task_list
+        await c.add_todo(summary="Some test task with a well-known uid", uid="well_known_1")
+
+        foo = await c.get_object_by_uid("well_known_1")
+        assert str(foo.icalendar_component["summary"]) == "Some test task with a well-known uid"
+
+        # prefix match must NOT succeed
+        with pytest.raises(error.NotFoundError):
+            await c.get_object_by_uid("well_known")
+
+        # suffix match must NOT succeed
+        with pytest.raises(error.NotFoundError):
+            await c.get_object_by_uid("well_known_10")
+
+    @pytest.mark.asyncio
+    async def test_load_event(self, async_calendar: Any, async_calendar2: Any) -> None:
+        """add_event() returns an object; load() must populate it."""
+        self.skip_unless_support("save-load.event")
+        self.skip_unless_support("create-calendar")
+
+        c1 = async_calendar
+
+        e1_ = await c1.add_event(ev1_static)
+        await e1_.load()  # load the object returned by add_event
+
+        events = await c1.get_events()
+        assert len(events) >= 1
+        e1 = events[0]
+        await e1.load()  # load a freshly fetched handle
+        assert e1.url == e1_.url
+
+    @pytest.mark.asyncio
+    async def test_copy_event(self, async_calendar: Any, async_calendar2: Any) -> None:
+        """copy() within same calendar and cross-calendar."""
+        self.skip_unless_support("save-load.event")
+        self.skip_unless_support("create-calendar")
+
+        c1 = async_calendar
+        c2 = async_calendar2
+
+        e1_ = await c1.add_event(ev1_static)
+        events = await c1.get_events()
+        e1 = events[0]
+
+        # duplicate in same calendar with a new UID
+        e1_dup = e1.copy()
+        await e1_dup.save()
+        assert len(await c1.get_events()) == 2
+
+        # copy cross-calendar keeping the same UID
+        if self.is_supported("save.duplicate-uid.cross-calendar"):
+            e1_in_c2 = e1.copy(new_parent=c2, keep_uid=True)
+            await e1_in_c2.save()
+            assert len(await c2.get_events()) == 1
+
+            # modifying the copy in c2 must not affect c1's event
+            e1_in_c2.icalendar_component["summary"] = "asdf"
+            await e1_in_c2.save()
+            await e1.load()
+            assert str(e1.icalendar_component["summary"]) == "Bastille Day Party"
+
+        # copy in same calendar keeping UID — same-UID PUT is a no-op / overwrite
+        e1_dup2 = e1.copy(keep_uid=True)
+        await e1_dup2.save()
+        # count should still be 2 (not 3) because same UID overwrites
+        assert len(await c1.get_events()) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_get(self, async_calendar: Any) -> None:
+        """multiget() retrieves multiple events in one request."""
+        self.skip_unless_support("save-load.event")
+
+        c = async_calendar
+
+        event1 = await c.add_event(
+            uid="test-multiget-1",
+            dtstart=datetime(2015, 1, 1, 8, 0, 0),
+            dtend=datetime(2015, 1, 1, 9, 0, 0),
+            summary="test-multiget-1",
+        )
+        event2 = await c.add_event(
+            uid="test-multiget-2",
+            dtstart=datetime(2015, 1, 1, 8, 0, 0),
+            dtend=datetime(2015, 1, 1, 9, 0, 0),
+            summary="test-multiget-2",
+        )
+
+        results = await c.multiget([event1.url, event2.url])
+        assert len(results) == 2
+        uids = {str(r.icalendar_component["uid"]) for r in results}
+        assert uids == {"test-multiget-1", "test-multiget-2"}
+
+        await event1.load_by_multiget()
 
 
 class _AsyncTestSchedulingBase:

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1322,12 +1322,8 @@ class RepeatedFunctionalTestsBaseClass:
         for flag in self.old_features:
             assert flag in incompatibility_description
 
-        if self.check_compatibility_flag("unique_calendar_ids"):
-            self.testcal_id = "testcalendar-" + str(uuid.uuid4())
-            self.testcal_id2 = "testcalendar-" + str(uuid.uuid4())
-        else:
-            self.testcal_id = "pythoncaldav-test"
-            self.testcal_id2 = "pythoncaldav-test2"
+        self.testcal_id = "pythoncaldav-test"
+        self.testcal_id2 = "pythoncaldav-test2"
 
         foo = self.is_supported("rate-limit", dict)
         if foo.get("enable"):
@@ -1408,8 +1404,6 @@ class RepeatedFunctionalTestsBaseClass:
                     pass
             else:
                 cal.delete()
-        if self.check_compatibility_flag("unique_calendar_ids") and mode == "pre":
-            a = self._teardownCalendar(name="Yep")
         for calid in (self.testcal_id, self.testcal_id2, self.testcal_id + "-tasks"):
             self._teardownCalendar(cal_id=calid)
         if self.cleanup_regime == "thorough":
@@ -1471,10 +1465,7 @@ class RepeatedFunctionalTestsBaseClass:
 
         # Pre-processing: set up defaults for name and cal_id
         if "name" not in kwargs:
-            if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-                "light",
-                "pre",
-            ):
+            if self.cleanup_regime in ("light", "pre"):
                 self._teardownCalendar(cal_id=self.testcal_id)
             if not self.is_supported("create-calendar.set-displayname"):
                 kwargs["name"] = None
@@ -2103,7 +2094,7 @@ END:VCALENDAR
             assert len(list(my_changed_objects)) == 0
 
         ## I was unable to run the rest of the tests towards Google using their legacy caldav API
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         ## MODIFYING an object
         if is_time_based:
@@ -2234,7 +2225,7 @@ END:VCALENDAR
             time.sleep(1)
 
         ## I was unable to run the rest of the tests towards Google using their legacy caldav API
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         ## MODIFYING an object
         obj.icalendar_instance.subcomponents[0]["SUMMARY"] = "foobar"
@@ -2291,10 +2282,7 @@ END:VCALENDAR
     def testLoadEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
         c1 = self._fixCalendar(name="Yep", cal_id=self.testcal_id)
@@ -2307,20 +2295,14 @@ END:VCALENDAR
         if not self.check_compatibility_flag("event_by_url_is_broken"):
             assert e1.url == e1_.url
             e1.load()
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
     def testCopyEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
@@ -2366,10 +2348,7 @@ END:VCALENDAR
         else:
             assert len(c1.get_events()) == 2
 
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
@@ -3496,10 +3475,7 @@ END:VCALENDAR
         # TODO: split up in creating a calendar with non-ascii name
         # and an event with non-ascii description
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
 
         c = self._fixCalendar(name="Yølp", cal_id=self.testcal_id)
@@ -3519,19 +3495,13 @@ END:VCALENDAR
         if "zimbra" not in str(c.url):
             assert len(events) == 1
 
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
 
     def testUnicodeEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
         c = self._fixCalendar(name="Yølp", cal_id=self.testcal_id)
 
@@ -3565,18 +3535,15 @@ END:VCALENDAR
 
         # Creating a new calendar with different ID but with existing name
         # TODO: why do we do this?
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        # TODO: we're doing this all over the placee, it should be consolidated
+        # TODO: it should be in the test setup/teardown
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id2)
         cc = self._fixCalendar(name="Yep", cal_id=self.testcal_id2)
         try:
             cc.delete()
         except error.DeleteError:
-            if not self.is_supported("delete-calendar") or self.check_compatibility_flag(
-                "unique_calendar_ids"
-            ):
+            if not self.is_supported("delete-calendar"):
                 raise
 
         c.set_properties(
@@ -3696,7 +3663,7 @@ END:VCALENDAR
 
         ## add same event again.  As it has same uid, it should be overwritten
         ## (but some calendars may throw a "409 Conflict")
-        if not self.check_compatibility_flag("no_overwrite"):
+        if self.is_supported("save-load.mutable"):
             e2 = c.add_event(ev1)
             if todo_ok:
                 t2 = c.add_todo(todo)
@@ -3742,7 +3709,7 @@ END:VCALENDAR
         # Verify that we can't look it up, both by URL and by ID
         with pytest.raises(self._notFound()):
             c.event_by_url(e1.url)
-        if not self.check_compatibility_flag("no_overwrite"):
+        if self.is_supported("save-load.mutable"):
             with pytest.raises(self._notFound()):
                 c.event_by_url(e2.url)
         if not self.check_compatibility_flag("event_by_url_is_broken"):
@@ -3799,7 +3766,7 @@ END:VCALENDAR
         ## (But events should not be immutable!  One should be able to change an event, push the changes
         ## out to all participants and all copies of the calendar, and let everyone know that it's a
         ## changed event and not a cancellation and a new event).
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         # ev2 is same UID, but one year ahead.
         # The timestamp should change.

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -3645,26 +3645,21 @@ END:VCALENDAR
         assert e1.url is not None
 
         # Verify that we can look it up, both by URL and by ID
-        if not self.check_compatibility_flag("event_by_url_is_broken"):
-            e2 = c.event_by_url(e1.url)
-            assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
-            assert e2.url == e1.url
+        e2 = c.event_by_url(e1.url)
+        assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        assert e2.url == e1.url
+
+        # look up by UID
         e3 = c.get_event_by_uid("20010712T182145Z-123401@example.com")
         assert e3.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
         assert e3.url == e1.url
 
-        # Knowing the URL of an event, we should be able to get to it
-        # without going through a calendar object
-        if not self.check_compatibility_flag("event_by_url_is_broken"):
-            e4 = Event(client=self.caldav, url=e1.url)
-            e4.load()
-            assert e4.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        e4 = Event(client=self.caldav, url=e1.url)
+        e4.load()
+        assert e4.id == e1.id
 
         with pytest.raises(error.NotFoundError):
-            c.get_event_by_uid("0")
-        c.add_event(evr)
-        with pytest.raises(error.NotFoundError):
-            c.get_event_by_uid("0")
+            c.get_event_by_uid("nonexistent-uid-0")
 
     def testCreateOverwriteDeleteEvent(self):
         """


### PR DESCRIPTION
There are still many more sync tests than async tests.  We should try to bring some symmetry to it.

This will involve duplicated code as far as I see it - I don't care so much about it as it's tests.  It may be a problem to keep things symmetric though - I need to think this through, perhaps we should introduce a "meta test" ensuring name matching between the sync and async tests.

revision 2ca8eac8056822a1f2150df73d921e8aff624c43 has some test breakages for ox and zimbra, I should look more into that before continuing the work here.

"Making async tests symmetric with sync tests" is tedious work involving quite a lot of code duplication, so in this pull request AI-generation will be heavily utilized.