### PR TITLE
Stalled: deprecate calendar_multiget in favour of multiget

### DIFF
--- a/caldav/async_davclient.py
+++ b/caldav/async_davclient.py
@@ -835,9 +835,9 @@ class AsyncDAVClient(BaseDAVClient):
             if _USE_HTTPX:
                 self.auth = httpx.DigestAuth(self.username, self.password)
             else:
-                from niquests.auth import HTTPDigestAuth
+                from niquests.auth import AsyncHTTPDigestAuth
 
-                self.auth = HTTPDigestAuth(self.username, self.password)
+                self.auth = AsyncHTTPDigestAuth(self.username, self.password)
         elif auth_type == "basic":
             if _USE_HTTPX:
                 self.auth = httpx.BasicAuth(self.username, self.password)

--- a/caldav/calendarobjectresource.py
+++ b/caldav/calendarobjectresource.py
@@ -1071,6 +1071,7 @@ class CalendarObjectResource(DAVObject):
     def _post_load_by_multiget(self, items):
         if not items:
             raise error.NotFoundError(self.url)
+        items = iter(items)
         url_data = next(items, None)
         if url_data is None:
             ## We shouldn't come here.  Something is wrong.

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -723,7 +723,14 @@ class Calendar(DAVObject):
 
         prop = dav.Prop()
         display_name = None
-        if name:
+        # Some servers (e.g. Zimbra) use the DisplayName from the MKCALENDAR body
+        # as the calendar URL, ignoring the actual request path.  When the server
+        # does not support setting a separate display name, omit it from the body so
+        # the request URL path is used as the calendar identifier.
+        supports_displayname = not self.client or self.client.features.is_supported(
+            "create-calendar.set-displayname"
+        )
+        if name and supports_displayname:
             display_name = dav.DisplayName(name)
             prop += [display_name]
         if supported_calendar_component_set:
@@ -747,7 +754,7 @@ class Calendar(DAVObject):
         # on setting the DisplayName on calendar creation
         # (DAViCal, Zimbra, ...).  Doing an attempt on explicitly setting the
         # display name using PROPPATCH.
-        if name:
+        if display_name:
             try:
                 self.set_properties([display_name])
             except Exception:
@@ -766,7 +773,7 @@ class Calendar(DAVObject):
         await self._query(root=mkcol, query_method=method, url=path, expected_return_value=201)
 
         # COMPATIBILITY ISSUE - try to set display name explicitly
-        if name:
+        if display_name:
             try:
                 await self.set_properties([display_name])
             except Exception:

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -1080,6 +1080,7 @@ class Calendar(DAVObject):
         """
         get multiple events' data.
         TODO: Does it overlap the _request_report_build_resultlist method
+        ## WARNING: async logic is duplicated in _async_multiget — mirror any changes there
         """
         if self.url is None:
             raise ValueError("Unexpected value None for self.url")
@@ -1098,28 +1099,33 @@ class Calendar(DAVObject):
         for r in results:
             yield (r, results[r][cdav.CalendarData.tag])
 
-    ## Replace the last lines with
+    def _post_multiget(self, results: Iterable[tuple[str, str]]) -> list[_CC]:
+        """Post-processing shared by multiget and _async_multiget_objects."""
+        return [
+            self._calendar_comp_class_by_data(data)(
+                self.client,
+                # Quote path to handle servers returning unencoded spaces (e.g., Zimbra)
+                url=self.url.join(quote(unquote(str(url)), safe="/:@")),
+                data=data,
+                parent=self,
+            )
+            for url, data in results
+        ]
+
     def multiget(self, event_urls: Iterable[URL], raise_notfound: bool = False) -> Iterable[_CC]:
         """
         get multiple events' data
         TODO: Does it overlap the _request_report_build_resultlist method?
         @author mtorange@gmail.com (refactored by Tobias)
         """
-        results = self._multiget(event_urls, raise_notfound=raise_notfound)
-        for url, data in results:
-            # Quote path to handle servers returning unencoded spaces (e.g., Zimbra)
-            quoted_url = quote(unquote(str(url)), safe="/:@")
-            yield self._calendar_comp_class_by_data(data)(
-                self.client,
-                url=self.url.join(quoted_url),
-                data=data,
-                parent=self,
-            )
+        if self.is_async_client:
+            return self._async_multiget_objects(event_urls, raise_notfound=raise_notfound)
+        return self._post_multiget(self._multiget(event_urls, raise_notfound=raise_notfound))
 
     async def _async_multiget(
         self, event_urls: Iterable[URL], raise_notfound: bool = False
     ) -> list[tuple[str, str]]:
-        """Async version of _multiget — returns a list of (url, data) tuples."""
+        ## WARNING: sync logic is duplicated in _multiget — mirror any changes there
         if self.url is None:
             raise ValueError("Unexpected value None for self.url")
 
@@ -1134,12 +1140,20 @@ class Calendar(DAVObject):
                     raise error.NotFoundError(f"Status {status} in {href}")
         return [(r, results[r][cdav.CalendarData.tag]) for r in results]
 
+    async def _async_multiget_objects(
+        self, event_urls: Iterable[URL], raise_notfound: bool = False
+    ) -> list[_CC]:
+        """Async version of multiget."""
+        return self._post_multiget(
+            await self._async_multiget(event_urls, raise_notfound=raise_notfound)
+        )
+
     def calendar_multiget(self, *largs, **kwargs):
         """
         get multiple events' data
         @author mtorange@gmail.com
         (refactored by Tobias)
-        This is for backward compatibility.  It may be removed in 3.0 or later release.
+        This is for backward compatibility.  It may be removed in a later release.
         """
         return list(self.multiget(*largs, **kwargs))
 

--- a/caldav/collection.py
+++ b/caldav/collection.py
@@ -1161,7 +1161,15 @@ class Calendar(DAVObject):
         @author mtorange@gmail.com
         (refactored by Tobias)
         This is for backward compatibility.  It may be removed in a later release.
+
+        .. deprecated::
+            Use :meth:`multiget` instead.
         """
+        warnings.warn(
+            "calendar_multiget is deprecated, use multiget instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return list(self.multiget(*largs, **kwargs))
 
     def date_search(

--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -77,6 +77,9 @@ class FeatureSet:
                 ## TODO: in the future, templates for the principal URL, calendar URLs etc may also be added.
             }
         },
+        "url": {
+            "type": "client-hints",
+        },
         "get-current-user-principal": {
             "description": "Support for RFC5397, current principal extension.  Most CalDAV servers have this, but it is an extension to the DAV standard.  Possibly observed missing on mail.ru, DavMail gateway and it is possible to configure the support in some sabre-based servers",
             "links": ["https://datatracker.ietf.org/doc/html/rfc5397"],
@@ -859,9 +862,6 @@ incompatibility_description = {
     'vtodo-cannot-be-uncompleted':
         """If a VTODO object has been set with STATUS:COMPLETE, it's not possible to delete the COMPLTEDED attribute and change back to STATUS:IN-ACTION""",
 
-    'unique_calendar_ids':
-        """For every test, generate a new and unique calendar id""",
-
     'sticky_events':
         """Events should be deleted before the calendar is deleted, """
         """and/or deleting a calendar may not have immediate effect""",
@@ -965,7 +965,6 @@ nextcloud = {
     'principal-search.by-name.self': {'support': 'unsupported'},
     'principal-search': {'support': 'ungraceful'},
     'search.time-range.open.start.duration': 'broken',
-    #'old_flags': ['unique_calendar_ids'],
     ## I'm surprised, I'm quite sure this was passing earlier.  Caldav commit a98d50490b872e9b9d8e93e2e401c936ad193003, caldav server checker commit 3cae24cf99da1702b851b5a74a9b88c8e5317dad
     'search.combined-is-logical-and': False,
     ## Observed with Nextcloud 33: server delivers iTIP notification to the inbox AND
@@ -997,7 +996,9 @@ ecloud = nextcloud | {
 zimbra = {
     'auto-connect.url': {'basepath': '/dav/'},
     'delete-calendar': {'support': 'fragile', 'behaviour': 'may move to trashbin instead of deleting immediately'},
-    'save-load.get-by-url': {'support': 'fragile', 'behaviour': '404 most of the time - but sometimes 200.  Weird, should be investigated more'},
+    ## This is a zimbra bug when creating calendars with a display
+    ## name.  Now mitigated in the calendar creation code.
+    #'save-load.get-by-url': {'support': 'fragile', 'behaviour': '404 most of the time - but sometimes 200.  Weird, should be investigated more'},
     ## Zimbra treats same-UID events across calendars as aliases of the same event
     'save.duplicate-uid.cross-calendar': {'support': 'unsupported'},
     'search.recurrences.expanded.exception': {'support': 'unsupported'}, ## TODO: verify
@@ -1160,7 +1161,6 @@ cyrus = {
 
 ## See comments on https://github.com/python-caldav/caldav/issues/3
 #icloud = [
-#    'unique_calendar_ids',
 #    'duplicate_in_other_calendar_with_same_uid_breaks',
 #    'sticky_events',
 #    'no_journal', ## it threw a 500 internal server error!

--- a/caldav/compatibility_hints.py
+++ b/caldav/compatibility_hints.py
@@ -177,6 +177,10 @@ class FeatureSet:
             "default": {"support": "full"},
             "links": ["https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.4.5"],
         },
+        "save-load.mutable": {
+            "description": "A saved calendar object resource can be modified and PUT back to the server; the server accepts the update and returns the modified data on the next GET/REPORT. When 'unsupported', the server treats calendar objects as immutable after initial creation (e.g. Google Calendar's legacy CalDAV API). Replaces the old 'no_overwrite' compatibility flag.",
+            "default": {"support": "full"},
+        },
         "search": {
             "description": "calendar MUST support searching for objects using the REPORT method, as specified in RFC4791, section 7",
             "links": ["https://datatracker.ietf.org/doc/html/rfc4791#section-7"],

--- a/docs/source/v3-migration.rst
+++ b/docs/source/v3-migration.rst
@@ -38,11 +38,11 @@ replace it with:
     from caldav import Event, Todo, Calendar           # OK
 
 All public symbols that were in ``caldav.objects`` should remain available directly
-from the ``caldav`` namespace
+from the ``caldav`` namespace.  Exceptions may apply.
 
 Wildcard import into caldav.* removed
 -------------------------------------
-Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but there are no guarantees that all imports will continue working.  If you have any issues, see :doc:`contact`.
+Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  Imports should work, but corner cases may exists.  If you have any issues, see :doc:`contact`.
 
 Config-file parse errors now raise exceptions
 ---------------------------------------------
@@ -308,9 +308,7 @@ context-manager "borrow" methods that give exclusive, safe write access.
 
 While inside the ``with`` block, the borrowed representation is the
 single source of truth.  Attempting to borrow a *different*
-representation raises ``RuntimeError``.  This means the current
-pattern is not completely thread-safe as of v3.x - but an explicit
-error is often better than updates silently being dropped.
+representation raises ``RuntimeError``.
 
 **The data representation remains the same:**
 

--- a/docs/source/v3-migration.rst
+++ b/docs/source/v3-migration.rst
@@ -2,12 +2,10 @@
 Migrating from caldav 2.x to 3.x
 =========================================
 
-v3.0 is mostly backward-compatible with v2.x.  Existing code should
+v3.x is mostly backward-compatible with v2.x.  Existing code should
 generally continue to run.  New method names and usage patterns exists
 alongside the old ones.  The purpose of this document is to give a
-primer on the "best current usage practice" as of v3.0.  It may be
-needed to implement some of the changes below before using future
-major versions like v4 or v5.
+primer on the "best current usage practice" as of v3.x.
 
 .. contents:: Contents
    :local:
@@ -44,9 +42,7 @@ from the ``caldav`` namespace
 
 Wildcard import into caldav.* removed
 -------------------------------------
-Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but I cannot give any guarantees that YOUR imports will continue working.  If you have any issues, then reach out.
-
-..todo:: how to add a link from "reach out" to the contact page?
+Earlier a wildcard import ``from caldav.objects import *`` was done into the ``caldav`` namespace.  This has been removed.  In normal circumstances, your imports should continue to work - but there are no guarantees that all imports will continue working.  If you have any issues, see :doc:`contact`.
 
 Config-file parse errors now raise exceptions
 ---------------------------------------------
@@ -247,7 +243,7 @@ Rationale: Those methods are also querying the server actively, and not just loo
 Accessing and editing calendar data
 =====================================
 
-This is the most significant new API in v3.0, addressing a long-standing
+This is the most significant new API in v3.x, addressing a long-standing
 ambiguity in how calendar object data was accessed and modified.
 
 The old ``vobject_instance``, ``icalendar_instance``, ``icalendar_component`` are now deprecated.
@@ -271,7 +267,7 @@ internal slot.  Accessing one representation could silently invalidate another:
 The 3.x Solution: read and edit methods
 -----------------------------------------
 
-v3.0 adds explicit read-only getters that always return **copies**, and
+v3.x adds explicit read-only getters that always return **copies**, and
 context-manager "borrow" methods that give exclusive, safe write access.
 
 **Read-only access** (safe at any time, returns a copy):
@@ -313,7 +309,7 @@ context-manager "borrow" methods that give exclusive, safe write access.
 While inside the ``with`` block, the borrowed representation is the
 single source of truth.  Attempting to borrow a *different*
 representation raises ``RuntimeError``.  This means the current
-pattern is not completely thread-safe as of v3.0 - but an explicit
+pattern is not completely thread-safe as of v3.x - but an explicit
 error is often better than updates silently being dropped.
 
 **The data representation remains the same:**
@@ -354,7 +350,7 @@ The interface for the string representation is still the same.  Strings are immu
      - Replace all data from a raw string
 
 
-New in v3.0
+New in v3.x
 ============
 
 Async client
@@ -486,10 +482,10 @@ If the server gives a `retry-after`-header on 429 or 530 it will be respected, o
 
 The total sleep period will never exceed 120, no matter if retry-after is given or not.
 
-Deprecated in v3.0 (will be removed in v4.0)
-=============================================
+Deprecated in v3.x
+==================
 
-The following emit ``DeprecationWarning``:
+The following emit ``DeprecationWarning`` and may be removed in v4.0:
 
 * ``calendar.date_search()`` — use ``calendar.search()``
 * ``client.principals()`` — use ``client.search_principals()``
@@ -498,7 +494,7 @@ The following emit ``DeprecationWarning``:
 * ``.instance`` property on calendar objects — use ``.vobject_instance``
 * ``response.find_objects_and_props()`` — use ``response.results``
 
-The following are deprecated but do **not yet** emit warnings:
+The following are deprecated, do **not yet** emit warnings and may be removed in v5.0:
 
 * All ``save_*`` methods → use ``add_*``
 * All ``*_by_uid()`` methods → use ``get_*_by_uid()``

--- a/examples/basic_usage_examples.py
+++ b/examples/basic_usage_examples.py
@@ -113,9 +113,6 @@ def find_delete_calendar_demo(my_principal, calendar_name):
 def add_stuff_to_calendar_demo(calendar):
     """
     This demo adds some stuff to the calendar
-
-    Unfortunately the arguments that it's possible to pass to save_* is poorly documented.
-    https://github.com/python-caldav/caldav/issues/253
     """
     ## Add an event with some certain attributes
     print("Saving an event")

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -620,7 +620,7 @@ class AsyncFunctionalTestsBaseClass:
         assert e1.url is not None
 
         # same UID again → overwrite (unless server forbids it)
-        if not self.is_supported("no-overwrite"):
+        if not self.is_supported("save-load.mutable"):
             e2 = await c.add_event(ev1_static)
 
             # no_create on an existing event must succeed
@@ -718,7 +718,7 @@ class AsyncFunctionalTestsBaseClass:
 
     @pytest.mark.asyncio
     async def test_multi_get(self, async_calendar: Any) -> None:
-        """calendar_multiget() retrieves multiple events in one request."""
+        """multiget() retrieves multiple events in one request."""
         self.skip_unless_support("save-load.event")
 
         c = async_calendar
@@ -736,7 +736,7 @@ class AsyncFunctionalTestsBaseClass:
             summary="test-multiget-2",
         )
 
-        results = await c.calendar_multiget([event1.url, event2.url])
+        results = await c.multiget([event1.url, event2.url])
         assert len(results) == 2
         uids = {str(r.icalendar_component["uid"]) for r in results}
         assert uids == {"test-multiget-1", "test-multiget-2"}

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -17,6 +17,17 @@ import pytest_asyncio
 
 from caldav.compatibility_hints import FeatureSet
 
+from .test_caldav import (
+    ev1 as ev1_static,  # old-date (2006); distinct from ev1() near-future generator
+)
+from .test_caldav import ev2 as ev2_static  # same UID as ev1_static, one year later
+from .test_caldav import ev3 as ev3_static  # different UID (2021)
+from .test_caldav import evr as evr_static  # recurring annual event (1997)
+from .test_caldav import evr2 as evr2_static  # bi-weekly with exception (2024)
+from .test_caldav import journal as journal_static
+from .test_caldav import todo as todo_static  # avoids clash with local var in add_todo()
+from .test_caldav import todo2 as todo2_static  # avoids clash with todo2() generator
+from .test_caldav import todo3 as todo3_static
 from .test_servers import TestServer, get_available_servers
 
 
@@ -289,6 +300,91 @@ class AsyncFunctionalTestsBaseClass:
                 await calendar.delete()
             except Exception:
                 pass
+
+    @pytest_asyncio.fixture
+    async def async_calendar2(self, async_client: Any) -> Any:
+        """Create a second test calendar for tests that need two distinct calendars."""
+        from caldav.aio import AsyncPrincipal
+        from caldav.lib.error import AuthorizationError, NotFoundError
+
+        from .fixture_helpers import aget_or_create_test_calendar
+
+        calendar_name = f"async-test2-{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+
+        principal = None
+        try:
+            principal = await AsyncPrincipal.create(async_client)
+        except (NotFoundError, AuthorizationError):
+            pass
+
+        calendar, created = await aget_or_create_test_calendar(
+            async_client, principal, calendar_name=calendar_name
+        )
+
+        if calendar is None:
+            pytest.skip("Could not create or find a second calendar for testing")
+
+        yield calendar
+
+        if created:
+            try:
+                await calendar.delete()
+            except Exception:
+                pass
+
+    @pytest_asyncio.fixture
+    async def async_journal_list(self, async_client: Any) -> Any:
+        """Create a VJOURNAL calendar for journal tests."""
+        from caldav.aio import AsyncPrincipal
+        from caldav.lib.error import AuthorizationError, NotFoundError
+
+        from .fixture_helpers import aget_or_create_test_calendar
+
+        calendar_name = f"async-journal-{datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+
+        principal = None
+        try:
+            principal = await AsyncPrincipal.create(async_client)
+        except (NotFoundError, AuthorizationError):
+            pass
+
+        calendar, created = await aget_or_create_test_calendar(
+            async_client,
+            principal,
+            calendar_name=calendar_name,
+            supported_calendar_component_set=["VJOURNAL"],
+        )
+
+        if calendar is None:
+            pytest.skip("Could not create or find a journal list for testing")
+
+        yield calendar
+
+        if created:
+            try:
+                await calendar.delete()
+            except Exception:
+                pass
+
+    async def _make_async_client_with_params(self, **overrides: Any) -> Any:
+        """Build a fresh async client from this server's config with kwargs overridden.
+
+        Used by auth-error tests (wrong password, wrong auth type) that need a
+        client that is expected to fail to connect.
+        """
+        from caldav.aio import get_async_davclient
+
+        kwargs: dict[str, Any] = {
+            "url": self.server.url,
+            "username": self.server.username,
+            "password": self.server.password,
+            "features": self.server.features,
+            "probe": False,
+        }
+        if "ssl_verify_cert" in self.server.config:
+            kwargs["ssl_verify_cert"] = self.server.config["ssl_verify_cert"]
+        kwargs.update(overrides)
+        return await get_async_davclient(**kwargs)
 
     # ==================== Test Methods ====================
 

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -584,8 +584,14 @@ class AsyncFunctionalTestsBaseClass:
         self.skip_unless_support("save-load.event")
         c = async_calendar
 
+        # create the event
         e1 = await c.add_event(ev1_static)
         assert e1.url is not None
+
+        # Verify that we can look it up from calendar by url
+        e2 = await c.event_by_url(e1.url)
+        assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        assert e2.url == e1.url
 
         # look up by UID
         e3 = await c.get_event_by_uid("20010712T182145Z-123401@example.com")

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -566,6 +566,183 @@ class AsyncFunctionalTestsBaseClass:
             f"ORGANIZER {org!r} should match the principal's address {expected_vcal!r}"
         )
 
+    # ==================== Group A – Core CRUD ====================
+
+    @pytest.mark.asyncio
+    async def test_get_supported_components(self, async_calendar: Any) -> None:
+        """get_supported_components() must include VEVENT."""
+        components = await async_calendar.get_supported_components()
+        assert components
+        assert "VEVENT" in components
+
+    @pytest.mark.asyncio
+    async def test_lookup_event(self, async_calendar: Any) -> None:
+        """Add an event and look it up by URL, by UID, and via Event(url=…).load()."""
+        from caldav import Event
+        from caldav.lib import error
+
+        self.skip_unless_support("save-load.event")
+        c = async_calendar
+
+        e1 = await c.add_event(ev1_static)
+        assert e1.url is not None
+
+        # look up by UID
+        e3 = await c.get_event_by_uid("20010712T182145Z-123401@example.com")
+        assert str(e3.icalendar_component["uid"]) == "20010712T182145Z-123401@example.com"
+        assert e3.url == e1.url
+
+        # load directly from URL without going through the calendar object
+        e4 = Event(client=c.client, url=e1.url)
+        await e4.load()
+        assert str(e4.icalendar_component["uid"]) == "20010712T182145Z-123401@example.com"
+
+        with pytest.raises(error.NotFoundError):
+            await c.get_event_by_uid("nonexistent-uid-000")
+
+    @pytest.mark.asyncio
+    async def test_create_overwrite_delete_event(self, async_calendar: Any) -> None:
+        """no_create/no_overwrite flags, same-UID overwrite, and delete."""
+        from caldav.lib import error
+
+        self.skip_unless_support("save-load.event")
+        c = async_calendar
+
+        # attempting to update a non-existing event must raise ConsistencyError
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_create=True)
+
+        # no_create + no_overwrite is always an error
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_create=True, no_overwrite=True)
+
+        e1 = await c.add_event(ev1_static)
+        assert e1.url is not None
+
+        # same UID again → overwrite (unless server forbids it)
+        if not self.is_supported("no-overwrite"):
+            e2 = await c.add_event(ev1_static)
+
+            # no_create on an existing event must succeed
+            e2 = await c.add_event(ev1_static, no_create=True)
+
+            # modify and save with no_create
+            e2.icalendar_component["summary"] = "Bastille Day Party!"
+            await e2.save(no_create=True)
+
+            e3 = await c.event_by_url(e1.url)
+            assert e3.icalendar_component["summary"] == "Bastille Day Party!"
+
+        # no_overwrite on an existing event must raise ConsistencyError
+        with pytest.raises(error.ConsistencyError):
+            await c.add_event(ev1_static, no_overwrite=True)
+
+        await e1.delete()
+
+        with pytest.raises(error.NotFoundError):
+            await c.event_by_url(e1.url)
+        with pytest.raises(error.NotFoundError):
+            await c.get_event_by_uid("20010712T182145Z-123401@example.com")
+
+    @pytest.mark.asyncio
+    async def test_object_by_uid(self, async_task_list: Any) -> None:
+        """Add a TODO with a known UID and retrieve it via get_object_by_uid()."""
+        from caldav.lib import error
+
+        c = async_task_list
+        await c.add_todo(summary="Some test task with a well-known uid", uid="well_known_1")
+
+        foo = await c.get_object_by_uid("well_known_1")
+        assert str(foo.icalendar_component["summary"]) == "Some test task with a well-known uid"
+
+        # prefix match must NOT succeed
+        with pytest.raises(error.NotFoundError):
+            await c.get_object_by_uid("well_known")
+
+        # suffix match must NOT succeed
+        with pytest.raises(error.NotFoundError):
+            await c.get_object_by_uid("well_known_10")
+
+    @pytest.mark.asyncio
+    async def test_load_event(self, async_calendar: Any, async_calendar2: Any) -> None:
+        """add_event() returns an object; load() must populate it."""
+        self.skip_unless_support("save-load.event")
+        self.skip_unless_support("create-calendar")
+
+        c1 = async_calendar
+
+        e1_ = await c1.add_event(ev1_static)
+        await e1_.load()  # load the object returned by add_event
+
+        events = await c1.get_events()
+        assert len(events) >= 1
+        e1 = events[0]
+        await e1.load()  # load a freshly fetched handle
+        assert e1.url == e1_.url
+
+    @pytest.mark.asyncio
+    async def test_copy_event(self, async_calendar: Any, async_calendar2: Any) -> None:
+        """copy() within same calendar and cross-calendar."""
+        self.skip_unless_support("save-load.event")
+        self.skip_unless_support("create-calendar")
+
+        c1 = async_calendar
+        c2 = async_calendar2
+
+        e1_ = await c1.add_event(ev1_static)
+        events = await c1.get_events()
+        e1 = events[0]
+
+        # duplicate in same calendar with a new UID
+        e1_dup = e1.copy()
+        await e1_dup.save()
+        assert len(await c1.get_events()) == 2
+
+        # copy cross-calendar keeping the same UID
+        if self.is_supported("save.duplicate-uid.cross-calendar"):
+            e1_in_c2 = e1.copy(new_parent=c2, keep_uid=True)
+            await e1_in_c2.save()
+            assert len(await c2.get_events()) == 1
+
+            # modifying the copy in c2 must not affect c1's event
+            e1_in_c2.icalendar_component["summary"] = "asdf"
+            await e1_in_c2.save()
+            await e1.load()
+            assert str(e1.icalendar_component["summary"]) == "Bastille Day Party"
+
+        # copy in same calendar keeping UID — same-UID PUT is a no-op / overwrite
+        e1_dup2 = e1.copy(keep_uid=True)
+        await e1_dup2.save()
+        # count should still be 2 (not 3) because same UID overwrites
+        assert len(await c1.get_events()) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_get(self, async_calendar: Any) -> None:
+        """calendar_multiget() retrieves multiple events in one request."""
+        self.skip_unless_support("save-load.event")
+
+        c = async_calendar
+
+        event1 = await c.add_event(
+            uid="test-multiget-1",
+            dtstart=datetime(2015, 1, 1, 8, 0, 0),
+            dtend=datetime(2015, 1, 1, 9, 0, 0),
+            summary="test-multiget-1",
+        )
+        event2 = await c.add_event(
+            uid="test-multiget-2",
+            dtstart=datetime(2015, 1, 1, 8, 0, 0),
+            dtend=datetime(2015, 1, 1, 9, 0, 0),
+            summary="test-multiget-2",
+        )
+
+        results = await c.calendar_multiget([event1.url, event2.url])
+        assert len(results) == 2
+        uids = {str(r.icalendar_component["uid"]) for r in results}
+        assert uids == {"test-multiget-1", "test-multiget-2"}
+
+        await event1.load_by_multiget()
+
 
 class _AsyncTestSchedulingBase:
     """

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -2103,7 +2103,7 @@ END:VCALENDAR
             assert len(list(my_changed_objects)) == 0
 
         ## I was unable to run the rest of the tests towards Google using their legacy caldav API
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         ## MODIFYING an object
         if is_time_based:
@@ -2234,7 +2234,7 @@ END:VCALENDAR
             time.sleep(1)
 
         ## I was unable to run the rest of the tests towards Google using their legacy caldav API
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         ## MODIFYING an object
         obj.icalendar_instance.subcomponents[0]["SUMMARY"] = "foobar"
@@ -3701,7 +3701,7 @@ END:VCALENDAR
 
         ## add same event again.  As it has same uid, it should be overwritten
         ## (but some calendars may throw a "409 Conflict")
-        if not self.check_compatibility_flag("no_overwrite"):
+        if self.is_supported("save-load.mutable"):
             e2 = c.add_event(ev1)
             if todo_ok:
                 t2 = c.add_todo(todo)
@@ -3747,7 +3747,7 @@ END:VCALENDAR
         # Verify that we can't look it up, both by URL and by ID
         with pytest.raises(self._notFound()):
             c.event_by_url(e1.url)
-        if not self.check_compatibility_flag("no_overwrite"):
+        if self.is_supported("save-load.mutable"):
             with pytest.raises(self._notFound()):
                 c.event_by_url(e2.url)
         if not self.check_compatibility_flag("event_by_url_is_broken"):
@@ -3804,7 +3804,7 @@ END:VCALENDAR
         ## (But events should not be immutable!  One should be able to change an event, push the changes
         ## out to all participants and all copies of the calendar, and let everyone know that it's a
         ## changed event and not a cancellation and a new event).
-        self.skip_on_compatibility_flag("no_overwrite")
+        self.skip_unless_support("save-load.mutable")
 
         # ev2 is same UID, but one year ahead.
         # The timestamp should change.

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -3645,26 +3645,21 @@ END:VCALENDAR
         assert e1.url is not None
 
         # Verify that we can look it up, both by URL and by ID
-        if not self.check_compatibility_flag("event_by_url_is_broken"):
-            e2 = c.event_by_url(e1.url)
-            assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
-            assert e2.url == e1.url
+        e2 = c.event_by_url(e1.url)
+        assert e2.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        assert e2.url == e1.url
+
+        # look up by UID
         e3 = c.get_event_by_uid("20010712T182145Z-123401@example.com")
         assert e3.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
         assert e3.url == e1.url
 
-        # Knowing the URL of an event, we should be able to get to it
-        # without going through a calendar object
-        if not self.check_compatibility_flag("event_by_url_is_broken"):
-            e4 = Event(client=self.caldav, url=e1.url)
-            e4.load()
-            assert e4.vobject_instance.vevent.uid == e1.vobject_instance.vevent.uid
+        e4 = Event(client=self.caldav, url=e1.url)
+        e4.load()
+        assert e4.id == e1.id
 
         with pytest.raises(error.NotFoundError):
-            c.get_event_by_uid("0")
-        c.add_event(evr)
-        with pytest.raises(error.NotFoundError):
-            c.get_event_by_uid("0")
+            c.get_event_by_uid("nonexistent-uid-0")
 
     def testCreateOverwriteDeleteEvent(self):
         """

--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1322,12 +1322,8 @@ class RepeatedFunctionalTestsBaseClass:
         for flag in self.old_features:
             assert flag in incompatibility_description
 
-        if self.check_compatibility_flag("unique_calendar_ids"):
-            self.testcal_id = "testcalendar-" + str(uuid.uuid4())
-            self.testcal_id2 = "testcalendar-" + str(uuid.uuid4())
-        else:
-            self.testcal_id = "pythoncaldav-test"
-            self.testcal_id2 = "pythoncaldav-test2"
+        self.testcal_id = "pythoncaldav-test"
+        self.testcal_id2 = "pythoncaldav-test2"
 
         foo = self.is_supported("rate-limit", dict)
         if foo.get("enable"):
@@ -1408,8 +1404,6 @@ class RepeatedFunctionalTestsBaseClass:
                     pass
             else:
                 cal.delete()
-        if self.check_compatibility_flag("unique_calendar_ids") and mode == "pre":
-            a = self._teardownCalendar(name="Yep")
         for calid in (self.testcal_id, self.testcal_id2, self.testcal_id + "-tasks"):
             self._teardownCalendar(cal_id=calid)
         if self.cleanup_regime == "thorough":
@@ -1471,10 +1465,7 @@ class RepeatedFunctionalTestsBaseClass:
 
         # Pre-processing: set up defaults for name and cal_id
         if "name" not in kwargs:
-            if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-                "light",
-                "pre",
-            ):
+            if self.cleanup_regime in ("light", "pre"):
                 self._teardownCalendar(cal_id=self.testcal_id)
             if not self.is_supported("create-calendar.set-displayname"):
                 kwargs["name"] = None
@@ -2291,10 +2282,7 @@ END:VCALENDAR
     def testLoadEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
         c1 = self._fixCalendar(name="Yep", cal_id=self.testcal_id)
@@ -2307,20 +2295,14 @@ END:VCALENDAR
         if not self.check_compatibility_flag("event_by_url_is_broken"):
             assert e1.url == e1_.url
             e1.load()
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
     def testCopyEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
@@ -2366,10 +2348,7 @@ END:VCALENDAR
         else:
             assert len(c1.get_events()) == 2
 
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
             self._teardownCalendar(cal_id=self.testcal_id2)
 
@@ -3496,10 +3475,7 @@ END:VCALENDAR
         # TODO: split up in creating a calendar with non-ascii name
         # and an event with non-ascii description
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
 
         c = self._fixCalendar(name="Yølp", cal_id=self.testcal_id)
@@ -3519,19 +3495,13 @@ END:VCALENDAR
         if "zimbra" not in str(c.url):
             assert len(events) == 1
 
-        if (
-            not self.check_compatibility_flag("unique_calendar_ids")
-            and self.cleanup_regime == "post"
-        ):
+        if self.cleanup_regime == "post":
             self._teardownCalendar(cal_id=self.testcal_id)
 
     def testUnicodeEvent(self):
         self.skip_unless_support("save-load.event")
         self.skip_unless_support("create-calendar")
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id)
         c = self._fixCalendar(name="Yølp", cal_id=self.testcal_id)
 
@@ -3565,18 +3535,15 @@ END:VCALENDAR
 
         # Creating a new calendar with different ID but with existing name
         # TODO: why do we do this?
-        if not self.check_compatibility_flag("unique_calendar_ids") and self.cleanup_regime in (
-            "light",
-            "pre",
-        ):
+        # TODO: we're doing this all over the placee, it should be consolidated
+        # TODO: it should be in the test setup/teardown
+        if self.cleanup_regime in ("light", "pre"):
             self._teardownCalendar(cal_id=self.testcal_id2)
         cc = self._fixCalendar(name="Yep", cal_id=self.testcal_id2)
         try:
             cc.delete()
         except error.DeleteError:
-            if not self.is_supported("delete-calendar") or self.check_compatibility_flag(
-                "unique_calendar_ids"
-            ):
+            if not self.is_supported("delete-calendar"):
                 raise
 
         c.set_properties(


### PR DESCRIPTION
This PR is slated for v4.0 and will not be merged before then.

`calendar_multiget()` is a legacy alias for `multiget()`.  This adds a
`DeprecationWarning` so callers have advance notice before the method is
removed in v4.0.

Deprecation warnings are deferred to a major release to avoid breaking
test suites that use `filterwarnings("error")`.