### PR TITLE
test: fix Cyrus 3.13.x regressions

### DIFF
--- a/tests/caldav_test_servers.yaml.example
+++ b/tests/caldav_test_servers.yaml.example
@@ -59,18 +59,19 @@ test-servers:
     enabled: ${TEST_CYRUS:-false}
     host: ${CYRUS_HOST:-localhost}
     port: ${CYRUS_PORT:-8802}
-    username: ${CYRUS_USERNAME:-testuser@test.local}
-    password: ${CYRUS_PASSWORD:-testpassword}
+    username: ${CYRUS_USERNAME:-user1}
+    password: ${CYRUS_PASSWORD:-x}
     # Cyrus pre-creates user1-user5 (password 'x'), enabling scheduling tests.
+    # Use plain usernames (no domain): virtdomains is off in the test image.
     scheduling_users:
       - url: http://${CYRUS_HOST:-localhost}:${CYRUS_PORT:-8802}/dav/calendars/user/user1
-        username: user1@test.local
+        username: user1
         password: x
       - url: http://${CYRUS_HOST:-localhost}:${CYRUS_PORT:-8802}/dav/calendars/user/user2
-        username: user2@test.local
+        username: user2
         password: x
       - url: http://${CYRUS_HOST:-localhost}:${CYRUS_PORT:-8802}/dav/calendars/user/user3
-        username: user3@test.local
+        username: user3
         password: x
 
   sogo:

--- a/tests/docker-test-servers/cyrus/setup_cyrus.sh
+++ b/tests/docker-test-servers/cyrus/setup_cyrus.sh
@@ -42,6 +42,18 @@ for i in $(seq 1 $max_caldav_attempts); do
 done
 
 echo ""
+echo "Granting scheduling ACL rights to pre-provisioned users..."
+# Cyrus 3.13.x pre-creates user1's calendar home in the Docker image without
+# the extended scheduling rights (7=schedule-send-invite, 8=schedule-send-reply,
+# 9=schedule-send-freebusy).  Dynamically-created calendar homes (user2+) get
+# these rights automatically, so we only need to patch user1 here, but grant
+# to all known pre-created users for safety.
+for user in user1 user2 user3 user4 user5; do
+    printf 'sam user.%s.#calendars.Outbox %s lrswipkxtecdan789\r\n' "$user" "$user"
+done | /usr/cyrus/bin/cyradm --auth PLAIN -u admin -w admin --notls --port 8143 localhost 2>/dev/null || \
+    echo "Warning: could not set scheduling ACL rights (cyradm failed)"
+
+echo ""
 echo "✓ Cyrus setup complete!"
 echo ""
 echo "Credentials:"


### PR DESCRIPTION
The Cyrus 3.13.x Docker image regressed on two fronts:

1. The image now runs with virtdomains: off (changed in 116231ab), so
   HTTP auth requires plain usernames (user1, user2, ...) rather than
   user@domain form.  Update caldav_test_servers.yaml.example to use
   plain usernames for both main credentials and scheduling_users.

2. The image pre-provisions user1's calendar home without the extended
   scheduling IMAP rights (7=schedule-send-invite, 8=schedule-send-reply,
   9=schedule-send-freebusy).  Dynamically-created calendar homes (user2+)
   receive these rights automatically when first accessed, but user1's
   pre-baked home does not.  Add a cyradm setacl step in setup_cyrus.sh
   that grants lrswipkxtecdan789 on each user's Outbox mailbox after the
   server is ready.

prompt: investigate cyrus AuthorizationError and testInviteAndRespond failures

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

AI Prompts:
claude-sonnet-4-6: I have rolled back to master.  Lots of cyrus tests fails due to AuthorizationError.  I've tried to restart the cyrus docker container.  Please investigate.
claude-sonnet-4-6: wait, the compatibility test is expected to fail because the caldav-server-tester is currently ahead of the caldav master
