### PR TITLE
Fix and improve tests

### DIFF
--- a/caldav/config.py
+++ b/caldav/config.py
@@ -112,9 +112,13 @@ def read_config(fn, interactive_error=False):
                     f"config file {fn} is not valid JSON, and pyyaml is not installed"
                 ) from None
 
-    except FileNotFoundError:
-        ## File not found
-        logging.debug(f"config file {fn} not found")
+    except OSError as e:
+        ## Optional config file is unusable (missing, a directory, no
+        ## permission, ...).  Treat any of these as "no config here" rather
+        ## than letting e.g. IsADirectoryError propagate out of an optional
+        ## config-file probe (happens when HOME is unset and the path expands
+        ## to something like '//.config//caldav/calendar.conf').
+        logging.debug(f"config file {fn} not usable: {e}")
         return {}
     except ValueError:
         # Re-raise ValueError so caller can handle config errors

--- a/caldav/testing.py
+++ b/caldav/testing.py
@@ -213,18 +213,24 @@ class XandikosServer(EmbeddedServer):
 
         if self.xapp_loop and self.xapp_runner:
 
-            async def cleanup_and_stop() -> None:
+            async def cleanup() -> None:
                 await self.xapp_runner.cleanup()
-                self.xapp_loop.stop()
 
             try:
-                asyncio.run_coroutine_threadsafe(cleanup_and_stop(), self.xapp_loop).result(
-                    timeout=10
-                )
+                asyncio.run_coroutine_threadsafe(cleanup(), self.xapp_loop).result(timeout=10)
             except Exception:
-                if self.xapp_loop:
-                    self.xapp_loop.call_soon_threadsafe(self.xapp_loop.stop)
-        elif self.xapp_loop:
+                # Best-effort cleanup: we swallow anything it raises (timeout,
+                # CancelledError, aiohttp errors).  The Xandikos server is
+                # ephemeral per test against a throwaway serverdir, so there is
+                # no shared state to release and nothing to recover here.
+                pass
+
+        # Stop the loop from *outside* any coroutine running on it.  Calling
+        # loop.stop() from within a coroutine scheduled via
+        # run_coroutine_threadsafe can stop the loop before it delivers that
+        # coroutine's result to the concurrent.futures.Future, so .result()
+        # would block until its timeout (~10s) on every single stop().
+        if self.xapp_loop:
             self.xapp_loop.call_soon_threadsafe(self.xapp_loop.stop)
 
         if self.thread:

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -186,9 +186,15 @@ class AsyncFunctionalTestsBaseClass:
         return flag in getattr(self._features, "_old_flags", [])
 
     @pytest.fixture(scope="class")
-    def test_server(self) -> TestServer:
-        """Get the test server for this class."""
-        server = self.server
+    @classmethod
+    def test_server(cls) -> TestServer:
+        """Get the test server for this class.
+
+        Defined as a classmethod because pytest deprecates class-scoped
+        fixtures written as plain instance methods (each test gets a fresh
+        instance, so per-instance state set here would not be visible anyway).
+        """
+        server = cls.server
         server.start()
         yield server
         # Stop the server to free the port for other test modules


### PR DESCRIPTION
hi there.

i ran into your repository while trying to fix some builds for nixpkgs on macos.
i ran into three problems:
- the tests were rather slow (felt like taking forever)
- some tests were failing
- some tests were only failing in nix build sandbox

i hope this changes are welcome.


# speed improvements
last successful job in this repo: https://github.com/python-caldav/caldav/actions/runs/27359451891/job/80842588388
```
[7](https://github.com/python-caldav/caldav/actions/runs/27359451891/job/80842588388#step:14:78)
========== 1394 passed, 169 skipped, 1 xpassed in 2165.85s (0:36:05) ===========
.pkg: _exit> python /opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
  py: OK (2195.64=setup[26.22]+cmd[2169.42] seconds)
  congratulations :) (2195.67 seconds)
```

with this branch locally:
```
================ 808 passed, 61 skipped, 1 xpassed in 167.14s (0:02:47) ================
.pkg: _exit> python /Users/betaboon/src/python/caldav/.venv/lib/python3.14/site-packages/pyproject_api/_backend.py True hatchling.build
  py: OK (168.95=setup[1.34]+cmd[167.61] seconds)
  congratulations :) (168.96 seconds)
```