### PR TITLE
Release prep for 3.3.0: the a1 companion replaces the 3.3.1 plan

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -56,3 +56,8 @@ http://x/
 https://ecloud\.global/remote\.php/.*
 https://tobixen@e\.email/remote\.php/dav
 https://dav\.qq\.com/.*
+
+# The CHANGELOG compare link for the release being prepared.  RELEASE-HOWTO
+# pushes the code before the tag, so this view 404s until `v3.3.0` is pushed -
+# delete this entry once it is.
+https://github\.com/python-caldav/caldav/compare/v3\.2\.1\.\.\.v3\.3\.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,13 @@ Changelogs prior to v3.0 are pruned, but are available in the v3.1 release
 
 This project should adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), though for pre-releases PEP 440 takes precedence.
 
-## [3.3.1] - **TODO: RELEASE-DATE**
+## [3.3.0] - 2026-09-02
 
-No changes from 3.3.0, except that the niquests dependency has been reintroduced (see the 3.3.0 breaking changes below).
+3.3.0 is mostly a maintenance and QA release.  The major news here is that we've done an AI-based (Claude Fable) review of all the code, this has resulted in quite a lot of hammering on the code to get all the issues found smoothened out.
 
-## [3.3.0] - **TODO: RELEASE-DATE**
-
-3.3 is mostly a maintenance and QA release.  The major news here is that we've done an AI-based (Claude Fable) review of all the code, this has resulted in quite a lot of hammering on the code to get all the issues found smoothened out.
+3.3.0a1 is a variant without any http-library in the dependencies - allowing projects that bring their own http-library to pin a caldav-version that does not bring in niquests.
 
 ### Breaking changes
-
-Niquests dependency dropped, to satisfy consumers wanting to depend on caldav without pulling in the niquests dependency.  If you want to continue using niquests, change the dependency from `caldav` to `caldav[niquests]`.  This change will be reverted in 3.3.1, to avoid breaking anything for consumers depending on "latest caldav".  If you don't want to drag in the niquests dependency, pin your dependency to 3.3.0 as for now (but look out and bump it if 3.3.2 will be released).  This is hacky ... but considered the only way to make everyone happy.
 
 The JMAP support has been declared experimental and `compatibility_hints.py` has been declared unstable, hence the two changes below are deemed allowable in a minor release:
 
@@ -35,7 +31,7 @@ The JMAP support has been declared experimental and `compatibility_hints.py` has
 ### Added
 
 * Work has been done on the HTTP library support and usage:
-  * `caldav[niquests]` is now a valid install target.  See also "Breaking changes" above.
+  * `caldav[niquests]` is now a valid install target.  Perhaps 4.x will come without any http library in the dependency-list.
   * Installing caldav with no HTTP library at all now fails with a message saying what to install - `pip install niquests`, or a dependency on `caldav[niquests]` rather than plain `caldav` - plus a link to the [HTTP Library Configuration](https://caldav.readthedocs.io/stable/http-libraries.html) documentation.  Previously it surfaced as a bare `ModuleNotFoundError: No module named 'requests'` from somewhere in the import chain.  Covers the sync and async CalDAV clients, `discovery`, `caldav.testing` and the JMAP clients; the async JMAP client is niquests-only and now says so.
   * The async client can now use **httpx2** - Pydantic's continuation of httpx - as its HTTP library.  The async fallback chain is niquests, httpx2, httpxyz, then httpx; the first one installed wins, and niquests remains the default and the recommended choice.  See also https://github.com/python-caldav/caldav/issues/611
   * The JMAP clients now keep a persistent HTTP session, so connections are reused across requests instead of a fresh TCP+TLS handshake per JMAP call.  `JMAPClient` and `AsyncJMAPClient` can be used as (async) context managers, and the session can also be released explicitly with `client.close()` / `await client.aclose()`.
@@ -609,6 +605,7 @@ In addition, lots of time spent on things that aren't covered by the roadmap:
 * Communication and collaboration
 * The release itself (running tests towards lots of servers with quirks - like having to wait for several minutes from when an event is edited until it can be found through a search operation - looking through and making sure the CHANGELOG is complete, etc) is quite tedious and easily takes several days - weeks if it's needed to tweak on workarounds and compatibility hints to get the tests passing.
 
+[3.3.0]: https://github.com/python-caldav/caldav/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/python-caldav/caldav/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/python-caldav/caldav/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/python-caldav/caldav/compare/v3.0.2...v3.1.0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The package is published at [Pypi](https://pypi.org/project/caldav)
 
 ## HTTP Libraries
 
-The sync client uses [niquests](https://github.com/jawah/niquests) by default (with fallback to [requests](https://requests.readthedocs.io/)). The async client uses [httpx](https://www.python-httpx.org/) if installed, otherwise falls back to niquests. See [HTTP Library Configuration](docs/source/http-libraries.rst) for details.
+The sync client uses [niquests](https://github.com/jawah/niquests) by default (with fallback to [requests](https://requests.readthedocs.io/)). The async client prefers niquests as well, falling back to the [httpx](https://www.python-httpx.org/) family (httpx2, httpxyz, httpx) - the first one installed wins. See [HTTP Library Configuration](docs/source/http-libraries.rst) for details.
 
 ## Licences
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,7 +63,7 @@ All code contributions are carefully reviewed by Tobias Brox.  Version tags are 
 
 The library comes with a number of dependencies, one may need to evaluate the security of those too.  The pyproject contains the current list.  Some notes:
 
-* niquests is an optional dependency - you may replace it with requests if you don't trust niquests
+* niquests is sort of an optional dependency - you may replace it with requests if you don't trust niquests, either by patching up pyproject.toml or by pinning your dependency to a designated alpha-version coming without this dependency.
 * recurring-ical-events and icalendar both have the same maintainer (Nicco Kunzmann).  He is considered trustworthy.
 * Tobias now has a policy of moving code not related to CalDAV into separate packages.  Those packages are most of the time either published under the `python-caldav` or `pycalendar` ownership on GitHub, and should be considered to be of the same quality and security level as the CalDAV library.
 * No independent security review has been done of the other dependencies - those are all considered to be mature and robust projects.

--- a/docs/design/RELEASE-HOWTO.md
+++ b/docs/design/RELEASE-HOWTO.md
@@ -45,6 +45,27 @@ I have no clue on the proper procedures for doing releases, and I keep on doing 
   does not track.  It runs in CI too, but run it here as well - CI checks the
   *repository*, this checks the *tree you are about to upload*.
 * Remove the release dir and its venv: `rm -r ~/caldav-release ~/caldav-release-venv`
+* Publish the companion alpha - the `niquests`-free variant.  Since 3.3.0, every
+  release has one, so that consumers who cannot pull in `niquests` (and the
+  `urllib3_future.pth` it brings - see
+  https://github.com/python-caldav/caldav/issues/690) have something to pin.
+  **Tag it on a throwaway branch, never on the release branch:**
+  ```
+  git checkout -b tmp-${VERSION}a1 v${VERSION}
+  ## drop "niquests" from [project] dependencies in pyproject.toml
+  git commit -am "chore: build ${VERSION}a1 without the niquests dependency"
+  git tag -as v${VERSION}a1
+  ```
+  then build and upload it exactly as above, from its own clean clone.  Push the
+  tag (`git push origin v${VERSION}a1`) but **do not push or merge the branch**,
+  and delete it locally afterwards.  The reason for the side branch is that
+  `hatch-vcs` derives the version from the nearest tag: an `a1` tag sitting on
+  the mainline as a descendant of `v${VERSION}` would make every subsequent dev
+  version be computed from `${VERSION}a1`, which under PEP 440 sorts *below*
+  `${VERSION}`.
+* Note in the release notes that the alpha exists and must be pinned exactly -
+  `caldav==${VERSION}a1`.  A range such as `caldav>=${VERSION}a1` still resolves
+  to the final release, since pip picks the highest eligible version.
 
 ## List of mistakes to be avoided
 
@@ -57,4 +78,5 @@ This is most likely not complete, but should explain some of the "silly" steps a
 * Having checked out a branch or tag or something, and tagging that as the new release rather than the latest HEAD.
 * Forgetting to push to pypi, or pushing something else than the tagged revision to pypi
 * Pushing out junk files in the pypi-release (i.e. .pyc-files, log files, temp files, `tests/conf_private.py`, `tests/caldav_test_servers.yaml`, an entire `venv/`, etc).  `tox -e package` now catches this - see the build step above
+* Forgetting the companion `a1` release, or tagging it on the release branch instead of a throwaway one (which poisons every later dev version number)
 * Not adding the release to the "github releases" (I don't care much about this feature, but apparently some people check there to find the latest release version)

--- a/docs/source/http-libraries.rst
+++ b/docs/source/http-libraries.rst
@@ -5,7 +5,7 @@ As of v3.x, **niquests** is the preferred, recommended and supported library for
 
 Due to popular demand, fallbacks to **requests** and to the **httpx** family (httpx, httpxyz, httpx2) exist.
 
-v4.x is planned to come without explicit dependencies on any HTTP library - the logic is that the consumer probably already imports some HTTP-library, and probably does not want to drag in another dependency.  For backward compatibility, it will be necessary to depend on ``caldav[niquests]`` rather than just ``caldav``.  Going forward from 3.3.0, every odd patch release will have ``niquests`` included in the dependencies, while every even patch release will have no http library dependencies, allowing consumers that don't want to drag in ``niquests`` (and the related ``urllib3-future``) to avoid them without having to patch the ``pyproject.toml`` file.
+v4.x is planned to come without explicit dependencies on any HTTP library - the logic is that the consumer probably already imports some HTTP-library, and probably does not want to drag in another dependency.  For backward compatibility, it will be necessary to depend on ``caldav[niquests]`` rather than just ``caldav``.  Going forward from 3.3.0, every release will have an associated ``3.x.ya1``-release, which is the same just without ``niquests`` included in the dependencies, allowing consumers that don't want to drag in ``niquests`` (and the related ``urllib3-future``) to avoid them by pinning dependencies to an alpha-release.
 
 Context
 -------
@@ -63,7 +63,7 @@ More information in the issue tracker:
 Fallbacks
 ---------
 
-To enable the fallbacks, just ensure the requests and/or httpxyz/httpx2/httpx library is available and that niquests isn't available.  In virtual environments, pin things to the latest even release.
+To enable the fallbacks, just ensure the requests and/or httpxyz/httpx2/httpx library is available and that niquests isn't available.  In virtual environments, pin things to an alpha-release.
 
 If *no* HTTP library at all is available, importing the client raises an
 ``ImportError`` naming the libraries that were tried and pointing at this


### PR DESCRIPTION
Release preparation for v3.3.0.

The text below was mostly AI-generated.  The commit is mostly human-generated

Sets the release date in the CHANGELOG, and replaces the "3.3.0 ships without
`niquests`, 3.3.1 puts it straight back" plan with the per-release `a1`
companion agreed in https://github.com/python-caldav/caldav/issues/690: every
release also gets an `a1` pre-release that is identical except that `niquests`
is not among its dependencies, so a plain `pip install caldav` can never land on
the http-library-free build by accident.

Also in here, from a review of the above:

* `docs/source/http-libraries.rst` — the new paragraph describing the scheme,
  plus the stale "pin things to the latest even release" advice in the Fallbacks
  section, which was left over from the abandoned odd/even plan.
* `docs/design/RELEASE-HOWTO.md` — a step for building and tagging the `a1`
  companion.  It has to be tagged on a throwaway branch that is never merged:
  `hatch-vcs` derives the version from the nearest tag, so an `a1` tag on the
  mainline would make every later dev version be computed from `3.3.0a1`, which
  under PEP 440 sorts *below* `3.3.0`.
* `README.md` — the async HTTP-library precedence was stated backwards; the
  chain is niquests, httpx2, httpxyz, httpx.
* `SECURITY.md` — `niquests` was described as an optional dependency, which it
  has not been since v3.0.

## One thing to undo after tagging

`.lycheeignore` carries a temporary entry for the `[3.3.0]` CHANGELOG compare
link.  That URL 404s until `v3.3.0` is pushed, and the code is pushed before the
tag, so the lychee pre-push hook would otherwise refuse the push.  **Delete that
entry once the tag is out** — the comment beside it says so.

## Not done here

No tag and no release; `tox -e package` and `twine` have not been run.  The `a1`
companion build has never been exercised, so the RELEASE-HOWTO step above is
reasoning about `hatch-vcs` rather than something that has been tried.
